### PR TITLE
chore(security): add service-role guard + docs (add-only)

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,6 +3,7 @@
     "check:webhook": "deno run -A scripts/check-webhook.ts",
     "ping:webhook": "deno run -A scripts/ping-webhook.ts",
     "set:webhook": "deno run -A scripts/set-webhook.ts",
-    "test:start": "deno test -A functions/_tests/start-command.test.ts"
+    "test:start": "deno test -A functions/_tests/start-command.test.ts",
+    "guard:service-role": "deno run -A scripts/guard-service-role.ts"
   }
 }

--- a/docs/SECURITY_service-role.md
+++ b/docs/SECURITY_service-role.md
@@ -1,0 +1,15 @@
+# Service Role Key — Usage & Safety
+
+- Use only in Supabase Edge Functions via Deno.env at runtime.
+- Never use in client code, tests, or GitHub Actions.
+- Prefer anon key for public reads; elevate via RPC where possible.
+
+## Rotation (recommended quarterly or after suspected exposure)
+npx supabase login
+npx supabase link --project-ref <PROJECT_REF>
+
+Generate a new key in Supabase dashboard (Settings → API), then update Edge Secrets:
+npx supabase secrets set SUPABASE_SERVICE_ROLE_KEY=<NEW_VALUE>
+
+Redeploy affected functions
+npx supabase functions deploy telegram-bot

--- a/scripts/guard-service-role.ts
+++ b/scripts/guard-service-role.ts
@@ -1,0 +1,52 @@
+const decoder = new TextDecoder();
+
+const allowGlobs = [
+  /^supabase\/functions\//,
+  /^functions\//
+];
+
+const isAllowed = (p: string) => allowGlobs.some((re) => re.test(p));
+
+const bannedSnippets = [
+  "SUPABASE_SERVICE_ROLE_KEY"
+];
+
+const isBinary = (buf: Uint8Array) => {
+  for (let i = 0; i < Math.min(buf.length, 1024); i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+};
+
+let bad = false;
+
+async function scan(dir: string) {
+  for await (const e of Deno.readDir(dir)) {
+    const p = `${dir}/${e.name}`;
+    if (e.isDirectory) {
+      if ([".git","node_modules","dist","build",".next",".turbo",".vercel",".vscode","coverage"].includes(e.name)) continue;
+      await scan(p);
+      continue;
+    }
+    if (!/\.(t|j)sx?$|\.env|\.md|\.yml|\.jsonc?$/.test(p)) continue;
+    const buf = await Deno.readFile(p);
+    if (isBinary(buf)) continue;
+    const txt = decoder.decode(buf);
+
+    // Hard rule: no literal-looking service-role key (very naive pattern)
+    // Matches long base64-like strings; adjust if you get false positives.
+    const highEntropy = /[A-Za-z0-9_\-]{40,}/g;
+    if (txt.match(highEntropy) && txt.includes("supabase")) {
+      console.error(`Possible secret material in ${p}. Remove and rotate if real.`);
+      bad = true;
+    }
+
+    // No direct reference to env name outside allowed server paths
+    if (!isAllowed(p) && bannedSnippets.some(s => txt.includes(s))) {
+      console.error(`Forbidden reference to SUPABASE_SERVICE_ROLE_KEY in ${p}`);
+      bad = true;
+    }
+  }
+}
+await scan(".");
+if (bad) Deno.exit(1);


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1

## Summary
- add script to guard against committing service-role key
- document safe usage & key rotation
- expose guard as Deno task

## Testing
- `deno run -A --no-npm scripts/guard-service-role.ts` *(fails: Forbidden reference to SUPABASE_SERVICE_ROLE_KEY in ./docs/api-documentation.md, etc.)*
- `npm test` *(fails: found telegram-bot handler module => ./functions/_tests/start-command.test.ts:31:6)*

------
https://chatgpt.com/codex/tasks/task_e_68993e5f9d2c8322b36c9c7a91d2985a