### PR TITLE
Refactor Telegram bot for offline testing

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,12 +18,17 @@ async function getClient(): Promise<SupabaseClient | null> {
     supabase = null;
     return null;
   }
-  const mod = await import(
-    typeof Deno !== "undefined"
-      ? "npm:@supabase/supabase-js@2"
-      : "@supabase/supabase-js"
-  );
-  supabase = mod.createClient(url, key, { auth: { persistSession: false } });
+  try {
+    const mod = await import(
+      typeof Deno !== "undefined"
+        ? "jsr:@supabase/supabase-js@2"
+        : "@supabase/supabase-js"
+    );
+    supabase = mod.createClient(url, key, { auth: { persistSession: false } });
+  } catch (_e) {
+    supabase = null;
+    return null;
+  }
   return supabase ?? null;
 }
 

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1,5 +1,5 @@
 // Enhanced admin handlers for comprehensive table management
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -1,5 +1,5 @@
 // Database utility functions for the Telegram bot
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||

--- a/supabase/functions/telegram-bot/helpers/beneficiary.ts
+++ b/supabase/functions/telegram-bot/helpers/beneficiary.ts
@@ -1,4 +1,4 @@
-import { type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 
 const BENEFICIARY_TABLE = Deno.env.get("BENEFICIARY_TABLE") ?? "beneficiaries";
 


### PR DESCRIPTION
## Summary
- use JSR imports and lazy loading to avoid npm during tests
- make feature flag config resilient when supabase-js is unavailable
- relax webhook secret check, enforcing only when provided and dropping it from required env vars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689958bb783c8322b6099d5d5b5975d5