### PR TITLE
feat(miniapp): create modern tailwind-based Telegram Mini App; align edge functions

### DIFF
--- a/apps/miniapp-react/.env.example
+++ b/apps/miniapp-react/.env.example
@@ -1,0 +1,4 @@
+VITE_SUPABASE_URL=https://<PROJECT_REF>.supabase.co
+VITE_SUPABASE_ANON_KEY=<PUBLIC_ANON_KEY>
+# Optionally pin project ref to avoid ?pr= in query
+VITE_SUPABASE_PROJECT_ID=<PROJECT_REF>

--- a/apps/miniapp-react/README.md
+++ b/apps/miniapp-react/README.md
@@ -1,0 +1,21 @@
+# Dynamic Capital — Telegram Mini App (React + Tailwind)
+
+- Landing page (`/`): greet user and direct to dashboard.
+- Dashboard (`/dashboard`): show VIP status and list active education packages.
+- Uses Telegram WebApp SDK; derives Supabase Functions URLs from the same project as the bot (`functionUrl()`).
+- Calls `verify-initdata` and `miniapp-health` on Supabase Edge; reads packages via Supabase REST (anon key only).
+- Responsive, modern Tailwind design with dark mode.
+
+## Development
+```bash
+cd apps/miniapp-react
+npm i
+npm run dev
+# open http://localhost:5173/?sb=https://<PROJECT>.supabase.co&anon=<ANON>&pr=<PROJECT_REF>
+```
+
+## Build / Deploy
+```bash
+npm run build
+# Upload apps/miniapp-react/dist to the domain you set in MINI_APP_URL.
+```

--- a/apps/miniapp-react/index.html
+++ b/apps/miniapp-react/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Dynamic Capital — VIP</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  </head>
+  <body class="bg-slate-50 dark:bg-slate-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/miniapp-react/package.json
+++ b/apps/miniapp-react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "miniapp-react",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5174"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/apps/miniapp-react/postcss.config.js
+++ b/apps/miniapp-react/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/apps/miniapp-react/src/index.css
+++ b/apps/miniapp-react/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { color-scheme: light dark; }
+.card { @apply rounded-2xl shadow bg-white/80 dark:bg-slate-800/80 backdrop-blur p-4; }
+.btn  { @apply inline-flex items-center justify-center rounded-xl px-4 py-2 font-medium shadow; }

--- a/apps/miniapp-react/src/lib/edge.ts
+++ b/apps/miniapp-react/src/lib/edge.ts
@@ -1,0 +1,17 @@
+export function getProjectRef(): string | null {
+  const pr = (import.meta as any).env?.VITE_SUPABASE_PROJECT_ID as string | undefined;
+  if (pr) return pr;
+  const sb = (import.meta as any).env?.VITE_SUPABASE_URL as string | undefined;
+  if (sb) { try { return new URL(sb).hostname.split('.')[0]; } catch {} }
+  return new URLSearchParams(location.search).get('pr');
+}
+export function functionUrl(name: string): string | null {
+  const ref = getProjectRef();
+  return ref ? `https://${ref}.functions.supabase.co/${name}` : null;
+}
+export function supabaseUrl(): string | null {
+  return (import.meta as any).env?.VITE_SUPABASE_URL || new URLSearchParams(location.search).get('sb');
+}
+export function anonKey(): string | null {
+  return (import.meta as any).env?.VITE_SUPABASE_ANON_KEY || new URLSearchParams(location.search).get('anon');
+}

--- a/apps/miniapp-react/src/main.tsx
+++ b/apps/miniapp-react/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './routes/App';
+import './index.css';
+
+const root = document.getElementById('root')!;
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apps/miniapp-react/src/routes/App.tsx
+++ b/apps/miniapp-react/src/routes/App.tsx
@@ -1,0 +1,24 @@
+import { Route, Routes, Navigate, Link, useLocation } from 'react-router-dom';
+import Landing from '@/routes/Landing';
+import Dashboard from '@/routes/Dashboard';
+
+export default function App() {
+  const loc = useLocation();
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 text-slate-900 dark:text-slate-100">
+      <nav className="sticky top-0 z-10 backdrop-blur bg-white/60 dark:bg-slate-900/60 border-b border-slate-200/50 dark:border-slate-700/40">
+        <div className="mx-auto max-w-xl px-4 h-14 flex items-center justify-between">
+          <Link to="/" className="font-semibold">Dynamic Capital</Link>
+          <div className="text-sm opacity-70">{loc.pathname === '/dashboard' ? 'Dashboard' : 'Home'}</div>
+        </div>
+      </nav>
+      <main className="mx-auto max-w-xl p-4">
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/routes/Dashboard.tsx
+++ b/apps/miniapp-react/src/routes/Dashboard.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useTelegram } from '@/shared/useTelegram';
+import { verifyInitData, getVipStatus, getPackages } from '@/services/api';
+import VipBadge from '@/shared/VipBadge';
+import PackageCard from '@/shared/PackageCard';
+
+type Pkg = { id: string; name: string; price: number; currency: string; thumbnail_url?: string; description?: string };
+
+export default function Dashboard() {
+  const { initData, user, haptic } = useTelegram();
+  const [vip, setVip] = useState<null | boolean>(null);
+  const [pkgs, setPkgs] = useState<Pkg[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (initData) await verifyInitData(initData);
+        const v = await getVipStatus(String(user?.id || ''));
+        setVip(v);
+        const list = await getPackages();
+        setPkgs(list);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [initData, user?.id]);
+
+  return (
+    <div className="space-y-4">
+      <section className="card">
+        <h2 className="text-xl font-semibold mb-1">Membership</h2>
+        <VipBadge value={vip} />
+        <div className="mt-3 flex gap-3">
+          <button className="btn bg-emerald-600 text-white hover:bg-emerald-700" onClick={() => haptic('medium')}>
+            Renew / Upgrade
+          </button>
+          <button className="btn bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100" onClick={() => haptic('light')}>
+            Support
+          </button>
+        </div>
+      </section>
+      <section className="card">
+        <h2 className="text-xl font-semibold mb-3">Education Packages</h2>
+        {loading && <div className="opacity-70 text-sm">Loading…</div>}
+        {!loading && (!pkgs || pkgs.length === 0) && <div className="opacity-70 text-sm">No packages found.</div>}
+        <div className="grid gap-3">
+          {pkgs?.map(p => <PackageCard key={p.id} pkg={p} />)}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/routes/Landing.tsx
+++ b/apps/miniapp-react/src/routes/Landing.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { useTelegram } from '@/shared/useTelegram';
+
+export default function Landing() {
+  const nav = useNavigate();
+  const { user } = useTelegram();
+  return (
+    <section className="card space-y-4">
+      <h1 className="text-2xl font-semibold">VIP Mini App</h1>
+      <p className="opacity-80">Welcome{user?.first_name ? `, ${user.first_name}` : ''}! Tap below to open your dashboard.</p>
+      <button className="btn bg-blue-600 text-white hover:bg-blue-700" onClick={() => nav('/dashboard')}>
+        Open Dashboard
+      </button>
+      <p className="text-xs opacity-60">{user ? `Telegram ID: ${user.id}` : 'No Telegram user detected yet.'}</p>
+    </section>
+  );
+}

--- a/apps/miniapp-react/src/services/api.ts
+++ b/apps/miniapp-react/src/services/api.ts
@@ -1,0 +1,30 @@
+import { functionUrl, supabaseUrl, anonKey } from '@/lib/edge';
+
+export async function verifyInitData(initData: string): Promise<boolean> {
+  const url = functionUrl('verify-initdata');
+  if (!url || !initData) return false;
+  try {
+    const r = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ initData }) });
+    return r.ok;
+  } catch { return false; }
+}
+
+export async function getVipStatus(telegramId: string): Promise<boolean | null> {
+  const url = functionUrl('miniapp-health');
+  if (!url || !telegramId) return null;
+  try {
+    const r = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ telegram_id: telegramId }) });
+    if (!r.ok) return null;
+    const j = await r.json();
+    return (j?.vip?.is_vip ?? null) as boolean | null;
+  } catch { return null; }
+}
+
+export async function getPackages(): Promise<any[]> {
+  const base = supabaseUrl(); const anon = anonKey();
+  if (!base || !anon) return [];
+  const url = `${base}/rest/v1/education_packages?select=id,name,price,currency,thumbnail_url,description,is_active&is_active=eq.true&order=created_at.desc&limit=12`;
+  const r = await fetch(url, { headers: { apikey: anon, Authorization: `Bearer ${anon}` } });
+  if (!r.ok) return [];
+  return (await r.json()) as any[];
+}

--- a/apps/miniapp-react/src/shared/PackageCard.tsx
+++ b/apps/miniapp-react/src/shared/PackageCard.tsx
@@ -1,0 +1,14 @@
+type P = { id: string; name: string; price: number; currency: string; thumbnail_url?: string; description?: string };
+export default function PackageCard({ pkg }: { pkg: P }) {
+  return (
+    <div className="grid grid-cols-[80px,1fr,auto] gap-3 items-center rounded-2xl shadow p-3 bg-white/80 dark:bg-slate-800/80 backdrop-blur">
+      <img src={pkg.thumbnail_url || 'https://via.placeholder.com/80'} className="w-20 h-20 rounded-xl object-cover" />
+      <div className="min-w-0">
+        <div className="font-medium truncate">{pkg.name}</div>
+        <div className="text-sm opacity-70 line-clamp-2">{pkg.description || ''}</div>
+        <div className="mt-1 text-sm">{pkg.price} {pkg.currency}</div>
+      </div>
+      <button className="btn bg-blue-600 text-white text-sm hover:bg-blue-700">Details</button>
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/shared/VipBadge.tsx
+++ b/apps/miniapp-react/src/shared/VipBadge.tsx
@@ -1,0 +1,5 @@
+export default function VipBadge({ value }: { value: boolean | null }) {
+  if (value === true) return <div className="inline-flex items-center gap-2 text-emerald-700 dark:text-emerald-400"><span className="h-2.5 w-2.5 rounded-full bg-emerald-500"></span>Active VIP</div>;
+  if (value === false) return <div className="inline-flex items-center gap-2 text-amber-700 dark:text-amber-400"><span className="h-2.5 w-2.5 rounded-full bg-amber-500"></span>Inactive / Expired</div>;
+  return <div className="inline-flex items-center gap-2 text-slate-500"><span className="h-2.5 w-2.5 rounded-full bg-slate-400"></span>Unknown</div>;
+}

--- a/apps/miniapp-react/src/shared/useTelegram.ts
+++ b/apps/miniapp-react/src/shared/useTelegram.ts
@@ -1,0 +1,18 @@
+import { useEffect, useMemo } from 'react';
+export function useTelegram() {
+  const tg = (window as any).Telegram?.WebApp;
+  useEffect(() => {
+    try {
+      tg?.ready?.();
+      tg?.expand?.();
+      const theme = tg?.colorScheme || 'light';
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+    } catch {}
+  }, []);
+  return useMemo(() => ({
+    initData: tg?.initData || '',
+    initDataUnsafe: tg?.initDataUnsafe || {},
+    user: tg?.initDataUnsafe?.user || null,
+    haptic: (strength: 'light'|'medium'|'heavy' = 'light') => tg?.HapticFeedback?.impactOccurred?.(strength)
+  }), [tg]);
+}

--- a/apps/miniapp-react/tailwind.config.ts
+++ b/apps/miniapp-react/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      borderRadius: { '2xl': '1.25rem' }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/apps/miniapp-react/tsconfig.json
+++ b/apps/miniapp-react/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["src"]
+}

--- a/apps/miniapp-react/vite.config.ts
+++ b/apps/miniapp-react/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173, host: '0.0.0.0' }
+});

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,6 +12,8 @@
     "miniapp:setmenu": "deno run -A scripts/set-chat-menu-button.ts",
     "audit:edge-hosts": "deno run -A scripts/audit-edge-hosts.ts",
     "linkage:check": "deno run -A scripts/check-linkage.ts",
-    "serve:linkage-audit": "supabase functions serve --no-verify-jwt linkage-audit"
+    "serve:linkage-audit": "supabase functions serve --no-verify-jwt linkage-audit",
+    "miniapp-react:dev": "bash scripts/miniapp-react-dev.sh",
+    "miniapp-react:build": "bash scripts/miniapp-react-build.sh"
   }
 }

--- a/scripts/miniapp-react-build.sh
+++ b/scripts/miniapp-react-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/../apps/miniapp-react" || exit 1
+npm run build

--- a/scripts/miniapp-react-dev.sh
+++ b/scripts/miniapp-react-dev.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/../apps/miniapp-react" || exit 1
+npm run dev


### PR DESCRIPTION
## Summary
- scaffold new `apps/miniapp-react` Telegram Mini App with React + Tailwind
- derive Supabase Edge URLs via shared `getProjectRef`/`functionUrl` helpers
- verify `initData`, display VIP status, and list education packages
- add dev/build scripts and tasks for miniapp-react

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899783c7f208322bed9ba1274f7bd75