### PR TITLE
fix(bot): detect MINI_APP_URL or short name; document setup

### DIFF
--- a/docs/MINI_APP_URL_SETUP.md
+++ b/docs/MINI_APP_URL_SETUP.md
@@ -2,27 +2,44 @@
 
 ## Why you see “Mini app not configured yet”
 
-The bot didn’t find `MINI_APP_URL` (or your function wasn’t redeployed after
-setting it).
+The bot didn’t find `MINI_APP_URL` or `MINI_APP_SHORT_NAME` (or your function
+wasn’t redeployed after setting them).
 
 ## Steps (prod)
 
-1. Set secrets in Supabase Edge: npx supabase login npx supabase link
-   --project-ref <PROJECT_REF> npx supabase secrets set
-   MINI_APP_URL=https://mini.dynamic.capital/
+1. Set secrets in Supabase Edge:
 
-ensure these are set as well: npx supabase secrets set
-TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook> npx supabase secrets set
-TELEGRAM_BOT_TOKEN=<token>
+   ```bash
+   npx supabase login
+   npx supabase link --project-ref <PROJECT_REF>
+   # Provide either a full URL or a short name
+   npx supabase secrets set MINI_APP_URL=https://mini.dynamic.capital/
+   # or
+   # npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
+   npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
+   npx supabase secrets set TELEGRAM_BOT_TOKEN=<token>
+   ```
 
-2. Redeploy the bot function so it reads new env: npx supabase functions deploy
-   telegram-bot
+2. Redeploy the bot function so it reads new env:
 
-3. (One-time) set Telegram chat menu button: export TELEGRAM_BOT_TOKEN=<token>
-   export MINI_APP_URL=https://mini.dynamic.capital/ deno run -A
-   scripts/set-chat-menu-button.ts
+   ```bash
+   npx supabase functions deploy telegram-bot
+   ```
 
-4. Sanity: deno run -A scripts/assert-miniapp-config.ts
+3. (One-time) set Telegram chat menu button:
+
+   ```bash
+   export TELEGRAM_BOT_TOKEN=<token>
+   export TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
+   deno run -A scripts/set-chat-menu-button.ts
+   ```
+
+4. Sanity:
+
+   ```bash
+   # TELEGRAM_WEBHOOK_SECRET must be in env
+   deno run -A scripts/assert-miniapp-config.ts
+   ```
 
 Notes:
 

--- a/scripts/assert-miniapp-config.ts
+++ b/scripts/assert-miniapp-config.ts
@@ -1,7 +1,10 @@
 // scripts/assert-miniapp-config.ts
 // Prints whether required Mini App envs are present at runtime (non-fatal).
 // Use locally or in CI to catch why the bot says "Mini app not configured yet".
-const MUST = ["MINI_APP_URL", "TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET"];
+import { functionUrl } from "../supabase/functions/_shared/edge.ts";
+
+const MUST = ["TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET"];
+const EITHER = ["MINI_APP_URL", "MINI_APP_SHORT_NAME"];
 const NICE = ["SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_PROJECT_ID"];
 
 function mark(k: string) {
@@ -11,9 +14,32 @@ function mark(k: string) {
 
 console.log("=== Mini App Preflight ===");
 for (const k of MUST) mark(k);
-for (const k of NICE) mark(k);
 console.log(
-  "Tip: set MINI_APP_URL in Supabase Edge secrets, then redeploy the telegram-bot function.",
+  `[preflight] MINI_APP_URL || MINI_APP_SHORT_NAME: ${
+    EITHER.some((k) => Deno.env.get(k)) ? "present" : "MISSING"
+  }`,
+);
+for (const k of NICE) mark(k);
+
+const secret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
+const fnUrl = functionUrl("telegram-bot");
+if (secret && fnUrl) {
+  try {
+    const res = await fetch(`${fnUrl}?miniapp-config=1&secret=${secret}`);
+    const cfg = await res.json();
+    console.log(
+      `[edge] MINI_APP_URL: ${cfg.mini_app_url ?? "MISSING"}`,
+    );
+    console.log(
+      `[edge] MINI_APP_SHORT_NAME: ${cfg.mini_app_short_name ?? "MISSING"}`,
+    );
+  } catch (e) {
+    console.log(`[edge] fetch error ${(e as Error).message}`);
+  }
+}
+
+console.log(
+  "Tip: set MINI_APP_URL or MINI_APP_SHORT_NAME in Supabase Edge secrets, then redeploy the telegram-bot function.",
 );
 // Never fail CI: exit 0.
 Deno.exit(0);

--- a/scripts/set-chat-menu-button.ts
+++ b/scripts/set-chat-menu-button.ts
@@ -1,15 +1,51 @@
 // scripts/set-chat-menu-button.ts
 // Sets a persistent chat menu button to open your Mini App.
-// Env needed: TELEGRAM_BOT_TOKEN, MINI_APP_URL
-const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
-const urlRaw = Deno.env.get("MINI_APP_URL");
+// Env needed: TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET, and
+// either SUPABASE_PROJECT_ID or SUPABASE_URL to resolve the function host.
+import { functionUrl } from "../supabase/functions/_shared/edge.ts";
 
-if (!token || !urlRaw) {
-  console.error("Need TELEGRAM_BOT_TOKEN and MINI_APP_URL in env.");
+const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const secret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
+
+if (!token || !secret) {
+  console.error(
+    "Need TELEGRAM_BOT_TOKEN and TELEGRAM_WEBHOOK_SECRET in env.",
+  );
   Deno.exit(1);
 }
 
-const url = urlRaw.endsWith("/") ? urlRaw : urlRaw + "/";
+const fnUrl = functionUrl("telegram-bot");
+if (!fnUrl) {
+  console.error("Could not determine Supabase Functions host");
+  Deno.exit(1);
+}
+
+const cfgRes = await fetch(`${fnUrl}?miniapp-config=1&secret=${secret}`);
+const cfg = await cfgRes.json();
+const urlRaw: string | null = cfg.mini_app_url ?? null;
+const shortName: string | null = cfg.mini_app_short_name ?? null;
+
+if (!urlRaw && !shortName) {
+  console.error("Mini app not configured in Edge function env.");
+  Deno.exit(1);
+}
+
+let url: string;
+if (shortName) {
+  const meRes = await fetch(
+    `https://api.telegram.org/bot${token}/getMe`,
+  );
+  const me = await meRes.json();
+  const username: string | undefined = me.result?.username;
+  if (!username) {
+    console.error("Could not determine bot username from getMe");
+    Deno.exit(1);
+  }
+  url = `https://t.me/${username}/${shortName}`;
+} else {
+  url = urlRaw!.endsWith("/") ? urlRaw! : urlRaw! + "/";
+}
+
 const payload = {
   menu_button: {
     type: "web_app",


### PR DESCRIPTION
## Summary
- expose miniapp config via edge function and reuse it in utility scripts
- fetch config from edge when setting chat menu button
- document edge-based setup and sanity check

## Testing
- `npm test`
- `deno run --no-npm -A scripts/assert-miniapp-config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68997ec540288322860203432dfe569c