### PR TITLE
chore(secrets): centralize env access and standardize Supabase Edge secrets usage

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -14,6 +14,7 @@
     "linkage:check": "deno run -A scripts/check-linkage.ts",
     "serve:linkage-audit": "supabase functions serve --no-verify-jwt linkage-audit",
     "miniapp-react:dev": "bash scripts/miniapp-react-dev.sh",
-    "miniapp-react:build": "bash scripts/miniapp-react-build.sh"
+    "miniapp-react:build": "bash scripts/miniapp-react-build.sh",
+    "guard:env": "deno run -A scripts/guard-env-usage.ts"
   }
 }

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,44 @@
+# Secrets Management
+
+All runtime secrets for the bot and mini app live in **Supabase Edge ➜ Functions
+➜ Secrets**. These values are injected at runtime by Supabase and should never
+be hard-coded.
+
+## Accessing secrets
+
+Use the helpers from `supabase/functions/_shared/env.ts`:
+
+- `getEnv(key)` – returns the value or throws if missing
+- `requireEnv([...keys])` – fetch multiple required keys at once
+- `optionalEnv(key)` – returns the value or `null` if absent
+
+Direct `Deno.env.get()` calls are forbidden outside `env.ts`. A guard task
+(`deno task guard:env`) enforces this.
+
+## Testing
+
+Tests can supply mock secrets without touching `Deno.env` via:
+
+```ts
+import {
+  clearTestEnv,
+  setTestEnv,
+} from "../../supabase/functions/_tests/env-mock.ts";
+
+setTestEnv({ TELEGRAM_BOT_TOKEN: "test-token" });
+// ...run code that reads env...
+clearTestEnv();
+```
+
+This injects values into `globalThis.__TEST_ENV__`, which the helpers read
+before falling back to real environment variables.
+
+## Adding new secrets
+
+1. Add the key name to the `EnvKey` union in
+   `supabase/functions/_shared/env.ts`.
+2. Access it via the helpers.
+3. Store the secret in Supabase Edge ➜ Functions ➜ Secrets.
+4. If used in tests, provide mock values with `setTestEnv`.
+
+Keep all secrets in Supabase; never commit them to the repository.

--- a/scripts/guard-env-usage.ts
+++ b/scripts/guard-env-usage.ts
@@ -1,0 +1,12 @@
+// scripts/guard-env-usage.ts
+import { walk } from "https://deno.land/std@0.224.0/fs/walk.ts";
+const allowed = ["supabase/functions/_shared/env.ts"];
+for await (const e of walk("supabase/functions")) {
+  if (!e.isFile || !e.path.endsWith(".ts")) continue;
+  if (allowed.includes(e.path)) continue;
+  const content = await Deno.readTextFile(e.path);
+  if (/Deno\.env\.get\(/.test(content)) {
+    console.error(`Forbidden direct Deno.env.get() usage in ${e.path}`);
+    Deno.exit(1);
+  }
+}

--- a/supabase/functions/_shared/edge.ts
+++ b/supabase/functions/_shared/edge.ts
@@ -2,15 +2,19 @@
 // Shared utilities to compute your Supabase Functions host and build URLs consistently.
 // Prefer using these helpers anywhere you call an Edge function.
 
+import { optionalEnv } from "./env.ts";
+
 export function getProjectRef(): string | null {
-  const ref = Deno.env.get("SUPABASE_PROJECT_ID");
+  const ref = optionalEnv("SUPABASE_PROJECT_ID");
   if (ref) return ref;
-  const url = Deno.env.get("SUPABASE_URL"); // e.g., https://qeejuomcapbdlhnjqjcc.supabase.co
+  const url = optionalEnv("SUPABASE_URL"); // e.g., https://qeejuomcapbdlhnjqjcc.supabase.co
   if (!url) return null;
   try {
     const m = new URL(url).hostname.split(".")[0];
     return m || null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 export function functionsHost(): string | null {

--- a/supabase/functions/_shared/env.ts
+++ b/supabase/functions/_shared/env.ts
@@ -1,0 +1,57 @@
+/** List all secrets used by the bot + mini app. Add here when new ones arise. */
+export type EnvKey =
+  | "SUPABASE_URL"
+  | "SUPABASE_ANON_KEY"
+  | "SUPABASE_SERVICE_ROLE_KEY"
+  | "SUPABASE_DB_URL"
+  | "SUPABASE_PROJECT_ID"
+  | "TELEGRAM_BOT_TOKEN"
+  | "TELEGRAM_WEBHOOK_SECRET"
+  | "TELEGRAM_BOT_USERNAME"
+  | "BINANCE_API_KEY"
+  | "BINANCE_SECRET_KEY"
+  | "OPENAI_API_KEY"
+  | "OPENAI_ENABLED"
+  | "FAQ_ENABLED"
+  | "SERVICE_ROLE_KEY"
+  | "PROJECT_ID"
+  | "PROJECT_URL"
+  | "DATABASE_PASSWORD"
+  | "MINI_APP_URL"
+  | "MINI_APP_SHORT_NAME"
+  | "BOT_VERSION"
+  | "WINDOW_SECONDS"
+  | "AMOUNT_TOLERANCE"
+  | "REQUIRE_PAY_CODE"
+  | "SB_REQUEST_ID"
+  | "BENEFICIARY_TABLE";
+
+/** Test-only env injection type */
+type TestEnv = Partial<Record<EnvKey, string>>;
+
+/** Get a single env value (production via Deno.env, tests via __TEST_ENV__). */
+export function getEnv<K extends EnvKey>(key: K): string {
+  const testEnv =
+    (globalThis as unknown as { __TEST_ENV__?: TestEnv }).__TEST_ENV__;
+  const v = Deno.env.get(key) ?? testEnv?.[key];
+  if (!v) throw new Error(`Missing required env: ${key}`);
+  return v;
+}
+
+/** Get a group of envs at once; will throw if any is missing. */
+export function requireEnv<K extends readonly EnvKey[]>(
+  keys: K,
+): Record<K[number], string> {
+  const out: Record<string, string> = {};
+  for (const key of keys as readonly EnvKey[]) {
+    out[key] = getEnv(key);
+  }
+  return out as Record<K[number], string>;
+}
+
+/** Optionally get an env (returns null if absent). */
+export function optionalEnv<K extends EnvKey>(key: K): string | null {
+  const testEnv =
+    (globalThis as unknown as { __TEST_ENV__?: TestEnv }).__TEST_ENV__;
+  return Deno.env.get(key) ?? testEnv?.[key] ?? null;
+}

--- a/supabase/functions/_tests/env-mock.ts
+++ b/supabase/functions/_tests/env-mock.ts
@@ -1,0 +1,10 @@
+// supabase/functions/_tests/env-mock.ts
+import { EnvKey } from "../_shared/env.ts";
+
+export function setTestEnv(values: Partial<Record<EnvKey, string>>) {
+  (globalThis as any).__TEST_ENV__ = { ...values };
+}
+
+export function clearTestEnv() {
+  delete (globalThis as any).__TEST_ENV__;
+}

--- a/supabase/functions/ai-faq-assistant/index.ts
+++ b/supabase/functions/ai-faq-assistant/index.ts
@@ -1,7 +1,8 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { requireEnv } from "../_shared/env.ts";
 
-const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+const { OPENAI_API_KEY } = requireEnv(["OPENAI_API_KEY"] as const);
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -67,7 +68,7 @@ Always end responses with: "💡 Need more help? Contact @DynamicCapital_Support
     const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${openAIApiKey}`,
+        "Authorization": `Bearer ${OPENAI_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/supabase/functions/analytics-data/index.ts
+++ b/supabase/functions/analytics-data/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { requireEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -20,9 +21,15 @@ serve(async (req) => {
   try {
     logStep("Analytics data request started");
 
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
+      [
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+      ] as const,
+    );
     const supabaseClient = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
       { auth: { persistSession: false } },
     );
 

--- a/supabase/functions/binance-pay-checkout/index.ts
+++ b/supabase/functions/binance-pay-checkout/index.ts
@@ -1,6 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
+import { optionalEnv, requireEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -9,8 +10,19 @@ const corsHeaders = {
 };
 
 // Binance Pay API configuration
-const _BINANCE_PAY_API_KEY = Deno.env.get("BINANCE_API_KEY")!;
-const _BINANCE_PAY_SECRET_KEY = Deno.env.get("BINANCE_SECRET_KEY")!;
+const {
+  BINANCE_API_KEY: _BINANCE_PAY_API_KEY,
+  BINANCE_SECRET_KEY: _BINANCE_PAY_SECRET_KEY,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = requireEnv(
+  [
+    "BINANCE_API_KEY",
+    "BINANCE_SECRET_KEY",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ] as const,
+);
 const _BINANCE_PAY_MERCHANT_ID = "59586072";
 const _BINANCE_PAY_BASE_URL = "https://bpay.binanceapi.com";
 
@@ -75,8 +87,8 @@ serve(async (req) => {
     }
 
     // Check if API keys are available
-    const binanceApiKey = Deno.env.get("BINANCE_API_KEY");
-    const binanceSecretKey = Deno.env.get("BINANCE_SECRET_KEY");
+    const binanceApiKey = optionalEnv("BINANCE_API_KEY");
+    const binanceSecretKey = optionalEnv("BINANCE_SECRET_KEY");
 
     console.log("API Keys check:", {
       hasApiKey: !!binanceApiKey,
@@ -90,14 +102,7 @@ serve(async (req) => {
     }
 
     // Initialize Supabase client
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error("Supabase configuration missing");
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseKey);
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
     console.log("Supabase client initialized");
 
     // Get plan details

--- a/supabase/functions/cleanup-old-receipts/index.ts
+++ b/supabase/functions/cleanup-old-receipts/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { requireEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -22,9 +23,15 @@ serve(async (req) => {
   try {
     logStep("Cleanup job started");
 
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
+      [
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+      ] as const,
+    );
     const supabaseClient = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
       { auth: { persistSession: false } },
     );
 

--- a/supabase/functions/cleanup-old-sessions/index.ts
+++ b/supabase/functions/cleanup-old-sessions/index.ts
@@ -1,11 +1,20 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
+import { requireEnv } from "../_shared/env.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  TELEGRAM_BOT_TOKEN: BOT_TOKEN,
+} = requireEnv(
+  [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "TELEGRAM_BOT_TOKEN",
+  ] as const,
+);
 
-const supabaseAdmin = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
   auth: { persistSession: false },
 });
 

--- a/supabase/functions/debug-bot/index.ts
+++ b/supabase/functions/debug-bot/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
-const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const BOT_TOKEN = optionalEnv("TELEGRAM_BOT_TOKEN");
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -56,7 +57,7 @@ serve(async (req) => {
     console.log("🔍 Webhook info:", JSON.stringify(webhookInfo, null, 2));
 
     // Test bot function URL
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseUrl = optionalEnv("SUPABASE_URL");
     const botFunctionUrl = `${supabaseUrl}/functions/v1/telegram-bot`;
 
     console.log("🧪 Testing bot function URL:", botFunctionUrl);

--- a/supabase/functions/keep-alive/index.ts
+++ b/supabase/functions/keep-alive/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,10 +34,7 @@ serve((req) => {
     // Start keep-alive on first request
     startKeepAlive();
 
-    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
-    if (!botToken) {
-      throw new Error("TELEGRAM_BOT_TOKEN is not set");
-    }
+    const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
     console.log("Keep-alive service started for telegram bot");
 

--- a/supabase/functions/miniapp-health/index.ts
+++ b/supabase/functions/miniapp-health/index.ts
@@ -13,13 +13,15 @@
 // Optional:
 //   SUPABASE_PROJECT_ID             (informational only)
 
+import { EnvKey, optionalEnv } from "../_shared/env.ts";
+
 type Json = Record<string, unknown>;
 
-function has(k: string) {
-  return (Deno.env.get(k) ?? "") !== "";
+function has(k: EnvKey) {
+  return optionalEnv(k) !== null;
 }
-function env(k: string) {
-  return Deno.env.get(k) ?? "";
+function env(k: EnvKey) {
+  return optionalEnv(k) ?? "";
 }
 
 async function headOk(url?: string): Promise<boolean> {

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -20,17 +21,11 @@ serve(async (req) => {
       );
     }
 
-    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
-    if (!botToken) {
-      throw new Error("TELEGRAM_BOT_TOKEN is not set");
-    }
+    const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
     console.log("Resetting Telegram bot...");
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    if (!supabaseUrl) {
-      throw new Error("SUPABASE_URL is not set");
-    }
+    const supabaseUrl = getEnv("SUPABASE_URL");
 
     // 1. Delete the current webhook
     const deleteResponse = await fetch(

--- a/supabase/functions/setup-telegram-webhook/index.ts
+++ b/supabase/functions/setup-telegram-webhook/index.ts
@@ -1,7 +1,12 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { requireEnv } from "../_shared/env.ts";
 
-const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const { TELEGRAM_BOT_TOKEN: BOT_TOKEN, SUPABASE_URL } = requireEnv(
+  [
+    "TELEGRAM_BOT_TOKEN",
+    "SUPABASE_URL",
+  ] as const,
+);
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -12,17 +13,11 @@ serve(async (req) => {
   }
 
   try {
-    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
-    if (!botToken) {
-      throw new Error("TELEGRAM_BOT_TOKEN is not set");
-    }
+    const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
     console.log("Setting up Telegram webhook...");
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    if (!supabaseUrl) {
-      throw new Error("SUPABASE_URL is not set");
-    }
+    const supabaseUrl = getEnv("SUPABASE_URL");
 
     // Get the webhook URL for our telegram-bot function
     const webhookUrl = `${supabaseUrl}/functions/v1/telegram-bot`;

--- a/supabase/functions/telegram-bot/_miniapp.ts
+++ b/supabase/functions/telegram-bot/_miniapp.ts
@@ -1,6 +1,8 @@
+import { optionalEnv } from "../_shared/env.ts";
+
 export function readMiniAppEnv() {
-  const urlRaw = Deno.env.get("MINI_APP_URL") || "";
-  const short = Deno.env.get("MINI_APP_SHORT_NAME") || "";
+  const urlRaw = optionalEnv("MINI_APP_URL") || "";
+  const short = optionalEnv("MINI_APP_SHORT_NAME") || "";
   const url = urlRaw ? (urlRaw.endsWith("/") ? urlRaw : urlRaw + "/") : "";
   return { url, short, ready: !!url || !!short };
 }

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1,9 +1,18 @@
 // Enhanced admin handlers for comprehensive table management
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { optionalEnv, requireEnv } from "../_shared/env.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
-  "";
+const {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  TELEGRAM_BOT_TOKEN: BOT_TOKEN,
+} = requireEnv(
+  [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "TELEGRAM_BOT_TOKEN",
+  ] as const,
+);
 
 const supabaseAdmin = createClient(
   SUPABASE_URL,
@@ -13,7 +22,6 @@ const supabaseAdmin = createClient(
 
 // Import utility functions
 import { getBotContent, logAdminAction } from "./database-utils.ts";
-import { requireEnv } from "./helpers/require-env.ts";
 // Removed cross-import of config helpers; provide local flag helpers for Edge isolation
 // Simple implementation stores flags in bot_settings with keys prefixed by "flag_"
 
@@ -32,7 +40,8 @@ async function preview(): Promise<{ data: FlagMap }> {
       const key: string = (row.setting_key as string) || "";
       const valRaw: string = String(row.setting_value ?? "");
       const normalized = valRaw.toLowerCase();
-      const boolVal = normalized === "true" || normalized === "1" || normalized === "on";
+      const boolVal = normalized === "true" || normalized === "1" ||
+        normalized === "on";
       map[key.replace(FLAG_PREFIX, "")] = boolVal;
     }
     return { data: map };
@@ -47,7 +56,11 @@ async function setFlag(name: string, value: boolean): Promise<void> {
     const key = `${FLAG_PREFIX}${name}`;
     const { error } = await supabaseAdmin
       .from("bot_settings")
-      .upsert({ setting_key: key, setting_value: value ? "true" : "false", is_active: true }, { onConflict: "setting_key" });
+      .upsert({
+        setting_key: key,
+        setting_value: value ? "true" : "false",
+        is_active: true,
+      }, { onConflict: "setting_key" });
     if (error) throw error;
   } catch (e) {
     console.error("setFlag error", e);
@@ -61,8 +74,6 @@ async function publishFlags(userId: string): Promise<void> {
 async function rollbackFlags(userId: string): Promise<void> {
   console.log("rollbackFlags invoked by", userId);
 }
-
-const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 
 export async function sendMessage(
   chatId: number,
@@ -1528,7 +1539,7 @@ export function handlePing() {
 }
 
 export function handleVersion() {
-  return { version: Deno.env.get("BOT_VERSION") || "unknown" };
+  return { version: optionalEnv("BOT_VERSION") || "unknown" };
 }
 
 export function handleEnvStatus() {

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -1,9 +1,13 @@
 // Database utility functions for the Telegram bot
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { requireEnv } from "../_shared/env.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
-  "";
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
+  [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ] as const,
+);
 
 const supabaseAdmin = createClient(
   SUPABASE_URL,

--- a/supabase/functions/telegram-bot/helpers/beneficiary.ts
+++ b/supabase/functions/telegram-bot/helpers/beneficiary.ts
@@ -1,6 +1,7 @@
 import { type SupabaseClient } from "jsr:@supabase/supabase-js@2";
+import { optionalEnv } from "../../_shared/env.ts";
 
-const BENEFICIARY_TABLE = Deno.env.get("BENEFICIARY_TABLE") ?? "beneficiaries";
+const BENEFICIARY_TABLE = optionalEnv("BENEFICIARY_TABLE") ?? "beneficiaries";
 
 export interface Beneficiary {
   account_name?: string | null;

--- a/supabase/functions/telegram-bot/helpers/require-env.ts
+++ b/supabase/functions/telegram-bot/helpers/require-env.ts
@@ -1,4 +1,6 @@
+import { EnvKey, optionalEnv } from "../../_shared/env.ts";
+
 export function requireEnv(keys: string[]): { ok: boolean; missing: string[] } {
-  const missing = keys.filter((k) => !Deno.env.get(k));
+  const missing = keys.filter((k) => !optionalEnv(k as EnvKey));
   return { ok: missing.length === 0, missing };
 }

--- a/supabase/functions/telegram-getwebhook/index.ts
+++ b/supabase/functions/telegram-getwebhook/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
-const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
-const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
-const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/, "");
+const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const FN = "telegram-webhook";
 const expected = BASE ? `${BASE}/functions/v1/${FN}` : null;
 

--- a/supabase/functions/telegram-selftest/index.ts
+++ b/supabase/functions/telegram-selftest/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
-const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
-const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
-const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/, "");
+const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const WEBHOOK = `${BASE}/functions/v1/telegram-webhook`;
 
 function tg(method: string, payload: unknown) {

--- a/supabase/functions/telegram-setwebhook/index.ts
+++ b/supabase/functions/telegram-setwebhook/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
-const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
-const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
-const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/, "");
+const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const FN = "telegram-webhook";
 const url = BASE ? `${BASE}/functions/v1/${FN}` : "";
 

--- a/supabase/functions/telegram-start-sim/index.ts
+++ b/supabase/functions/telegram-start-sim/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   const headers = {
@@ -31,7 +32,7 @@ serve(async (req) => {
       );
     }
 
-    const base = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/, "");
+    const base = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
     if (!base) {
       return new Response(
         JSON.stringify({ ok: false, error: "SUPABASE_URL not set" }),
@@ -55,7 +56,7 @@ serve(async (req) => {
       "Content-Type": "application/json",
     };
 
-    const secret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
+    const secret = optionalEnv("TELEGRAM_WEBHOOK_SECRET");
     if (secret) {
       fetchHeaders["x-telegram-bot-api-secret-token"] = secret;
     }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -1,19 +1,4 @@
-function getEnv(key: string): string {
-  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    return Deno.env.get(key) ?? "";
-  }
-  const nodeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
-  if (nodeProcess?.env) {
-    return nodeProcess.env[key] ?? "";
-  }
-  return "";
-}
-
-const nodeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
-if (nodeProcess?.env) {
-  nodeProcess.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-}
-
+import { optionalEnv } from "../_shared/env.ts";
 
 interface TelegramMessage {
   text?: string;
@@ -25,7 +10,7 @@ interface TelegramUpdate {
 }
 
 async function sendMessage(chatId: number, text: string) {
-  const token = getEnv("TELEGRAM_BOT_TOKEN");
+  const token = optionalEnv("TELEGRAM_BOT_TOKEN");
   if (!token) return;
   try {
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
@@ -40,7 +25,7 @@ async function sendMessage(chatId: number, text: string) {
 
 export async function handler(req: Request): Promise<Response> {
   const headers = { "Content-Type": "application/json" };
-  const WEBHOOK_SECRET = getEnv("TELEGRAM_WEBHOOK_SECRET");
+  const WEBHOOK_SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
 
   // Only accept POST requests
   if (req.method !== "POST") {

--- a/supabase/functions/test-bot-status/index.ts
+++ b/supabase/functions/test-bot-status/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -12,10 +13,7 @@ serve(async (req) => {
   }
 
   try {
-    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
-    if (!botToken) {
-      throw new Error("TELEGRAM_BOT_TOKEN is not set");
-    }
+    const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
     console.log("Testing bot status...");
 

--- a/supabase/functions/test-webhook/index.ts
+++ b/supabase/functions/test-webhook/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { optionalEnv } from "../_shared/env.ts";
 
-const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const BOT_TOKEN = optionalEnv("TELEGRAM_BOT_TOKEN");
 
 serve(async (req) => {
   console.log("🔧 WEBHOOK TEST FUNCTION CALLED!");

--- a/supabase/functions/tg-verify-init/index.ts
+++ b/supabase/functions/tg-verify-init/index.ts
@@ -1,9 +1,10 @@
 // >>> DC BLOCK: tg-verify-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { encode as hex } from "https://deno.land/std@0.224.0/encoding/hex.ts";
+import { getEnv, optionalEnv } from "../_shared/env.ts";
 
-const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
-const WEBHOOK_SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
+const BOT = getEnv("TELEGRAM_BOT_TOKEN");
+const WEBHOOK_SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
 
 function subtle() {
   const s = globalThis.crypto?.subtle;

--- a/supabase/functions/theme-get/index.ts
+++ b/supabase/functions/theme-get/index.ts
@@ -1,5 +1,6 @@
 // >>> DC BLOCK: theme-get-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv, requireEnv } from "../_shared/env.ts";
 
 function parseToken(bearer: string | undefined) {
   if (!bearer?.startsWith("Bearer ")) return 0;
@@ -20,11 +21,15 @@ serve(async (req) => {
   }
   // Try bot_settings(setting_key=`theme:${uid}`)
   try {
-    const url = Deno.env.get("SUPABASE_URL")!;
-    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
-      Deno.env.get("SUPABASE_ANON_KEY")!;
+    const { SUPABASE_URL, SUPABASE_ANON_KEY } = requireEnv(
+      [
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+      ] as const,
+    );
+    const key = optionalEnv("SUPABASE_SERVICE_ROLE_KEY") || SUPABASE_ANON_KEY;
     const res = await fetch(
-      `${url}/rest/v1/bot_settings?select=setting_value&setting_key=eq.theme:${uid}`,
+      `${SUPABASE_URL}/rest/v1/bot_settings?select=setting_value&setting_key=eq.theme:${uid}`,
       {
         headers: { apikey: key, Authorization: `Bearer ${key}` },
       },

--- a/supabase/functions/theme-save/index.ts
+++ b/supabase/functions/theme-save/index.ts
@@ -1,5 +1,6 @@
 // >>> DC BLOCK: theme-save-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv, requireEnv } from "../_shared/env.ts";
 
 function parseToken(bearer: string | undefined) {
   if (!bearer?.startsWith("Bearer ")) return 0;
@@ -25,9 +26,13 @@ serve(async (req) => {
     });
   }
   try {
-    const url = Deno.env.get("SUPABASE_URL")!;
-    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
-      Deno.env.get("SUPABASE_ANON_KEY")!;
+    const { SUPABASE_URL, SUPABASE_ANON_KEY } = requireEnv(
+      [
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+      ] as const,
+    );
+    const key = optionalEnv("SUPABASE_SERVICE_ROLE_KEY") || SUPABASE_ANON_KEY;
     // upsert into bot_settings
     const body = [{
       setting_key: `theme:${uid}`,
@@ -35,7 +40,7 @@ serve(async (req) => {
       description: "miniapp theme",
       is_system: false,
     }];
-    const r = await fetch(`${url}/rest/v1/bot_settings`, {
+    const r = await fetch(`${SUPABASE_URL}/rest/v1/bot_settings`, {
       method: "POST",
       headers: {
         apikey: key,

--- a/supabase/functions/trade-helper/index.ts
+++ b/supabase/functions/trade-helper/index.ts
@@ -1,7 +1,8 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { requireEnv } from "../_shared/env.ts";
 
-const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+const { OPENAI_API_KEY } = requireEnv(["OPENAI_API_KEY"] as const);
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -84,7 +85,7 @@ Remember to keep this educational and include proper risk disclaimers.`;
     const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${openAIApiKey}`,
+        "Authorization": `Bearer ${OPENAI_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/supabase/functions/verify-telegram/index.ts
+++ b/supabase/functions/verify-telegram/index.ts
@@ -1,3 +1,5 @@
+import { optionalEnv } from "../_shared/env.ts";
+
 // Verify Telegram WebApp initData according to Telegram spec
 // Public Edge Function with CORS
 
@@ -33,7 +35,7 @@ function parseInitData(initData: string): Record<string, string> {
 
 async function verifyInitData(initData: string) {
   const encoder = new TextEncoder();
-  const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+  const botToken = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
   if (!botToken) {
     return { ok: false, error: "BOT_TOKEN_NOT_SET" } as const;
   }


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Centralizes secret access via supabase/functions/_shared/env.ts. Updates functions to call getEnv/requireEnv/optionalEnv. Adds test injection and guard script. See docs/SECRETS.md for usage.

------
https://chatgpt.com/codex/tasks/task_e_689989cee59c83228bcce48a5a1f0b11