### PR TITLE
feat(admin): Phase 4 — approve/reject payments, activate VIP, expiry cron + reminders, admin logs

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -27,6 +27,8 @@
     "edge:deploy:plans": "npx supabase functions deploy plans",
     "edge:deploy:checkout": "npx supabase functions deploy checkout-init",
     "edge:deploy:uploadurl": "npx supabase functions deploy receipt-upload-url",
-    "edge:deploy:receipt": "npx supabase functions deploy receipt-submit"
+    "edge:deploy:receipt": "npx supabase functions deploy receipt-submit",
+    "edge:deploy:review": "npx supabase functions deploy admin-review-payment",
+    "edge:deploy:cron": "npx supabase functions deploy subscriptions-cron"
   }
 }

--- a/docs/PHASE_4_ADMIN.md
+++ b/docs/PHASE_4_ADMIN.md
@@ -1,0 +1,23 @@
+# Phase 4 — Admin approvals & VIP lifecycle
+
+## Endpoints
+
+- POST /admin-review-payment Headers: X-Admin-Secret: $ADMIN_API_SECRET Body: {
+  admin_telegram_id, payment_id, decision: "approve"|"reject", months?, message?
+  }
+
+- Scheduled: /subscriptions-cron Flip is_vip=false on expired, and send
+  reminders at D-7 and D-1.
+
+## Secrets
+
+- ADMIN_API_SECRET (hex)
+- TELEGRAM_ADMIN_IDS (comma-separated)
+- TELEGRAM_BOT_TOKEN (for user notifications)
+
+## Flows
+
+- Approve: marks payment completed, extends expiry from current expiry or now,
+  sets is_vip=true, logs to admin_logs, notifies user.
+- Reject: marks payment rejected, logs, notifies user.
+- Cron: reminders + auto-expire + logs.

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -1,0 +1,167 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getEnv, optionalEnv } from "../_shared/env.ts";
+
+type Body = {
+  admin_telegram_id?: string;
+  payment_id: string;
+  decision: "approve" | "reject";
+  months?: number;
+  message?: string;
+};
+
+function csvToSet(s?: string | null) {
+  return new Set(
+    (s || "").split(",").map((x) => x.trim()).filter(Boolean),
+  );
+}
+
+async function tgSend(token: string, chatId: string, text: string) {
+  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+  }).catch(() => {});
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const hdr = req.headers.get("X-Admin-Secret") || "";
+  const EXPECT = getEnv("ADMIN_API_SECRET");
+  if (hdr !== EXPECT) return new Response("Unauthorized", { status: 401 });
+
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+  if (!body?.payment_id || !body?.decision) {
+    return new Response("Missing fields", { status: 400 });
+  }
+
+  const adminId = String(body.admin_telegram_id || "");
+  const admins = csvToSet(optionalEnv("TELEGRAM_ADMIN_IDS"));
+  if (admins.size && (!adminId || !admins.has(adminId))) {
+    return new Response("Admin not allowed", { status: 403 });
+  }
+
+  const url = getEnv("SUPABASE_URL");
+  const svc = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const botToken = getEnv("TELEGRAM_BOT_TOKEN");
+
+  const { data: p, error: perr } = await supa
+    .from("payments")
+    .select("id,status,user_id,plan_id,amount,currency,created_at")
+    .eq("id", body.payment_id)
+    .maybeSingle();
+  if (perr || !p) return new Response("Payment not found", { status: 404 });
+
+  const { data: prof, error: uerr } = await supa
+    .from("bot_users")
+    .select("id,telegram_id,subscription_expires_at,is_vip")
+    .eq("id", p.user_id)
+    .maybeSingle();
+  if (uerr || !prof) return new Response("User not found", { status: 404 });
+
+  let newStatus = p.status;
+  let expiresAt: string | null = prof.subscription_expires_at
+    ? new Date(prof.subscription_expires_at).toISOString()
+    : null;
+
+  if (body.decision === "reject") {
+    newStatus = "rejected";
+    await supa.from("payments").update({ status: newStatus }).eq("id", p.id);
+
+    if (prof.telegram_id) {
+      const msg = body.message ||
+        "Your payment was rejected. Please contact support.";
+      await tgSend(
+        botToken,
+        String(prof.telegram_id),
+        `❌ <b>Payment Rejected</b>\n${msg}`,
+      );
+    }
+
+    await supa.from("admin_logs").insert({
+      admin_telegram_id: adminId || "unknown",
+      action_type: "payment_rejected",
+      action_description: `Payment ${p.id} rejected`,
+      affected_table: "payments",
+      affected_record_id: p.id,
+      new_values: { status: newStatus },
+    });
+
+    return new Response(
+      JSON.stringify({ ok: true, status: newStatus }),
+      { headers: { "content-type": "application/json" } },
+    );
+  }
+
+  let months = Number.isFinite(body.months) ? Number(body.months) : null;
+  if (!months) {
+    const { data: plan } = await supa
+      .from("subscription_plans")
+      .select("duration_months,is_lifetime")
+      .eq("id", p.plan_id)
+      .maybeSingle();
+    if (plan?.is_lifetime) months = 1200;
+    else months = plan?.duration_months || 1;
+  }
+
+  const now = new Date();
+  const base = prof.subscription_expires_at &&
+      new Date(prof.subscription_expires_at) > now
+    ? new Date(prof.subscription_expires_at)
+    : now;
+  const next = new Date(base);
+  next.setMonth(next.getMonth() + (months || 1));
+  expiresAt = next.toISOString();
+
+  newStatus = "completed";
+  await supa.from("payments").update({ status: newStatus }).eq("id", p.id);
+
+  await supa.from("user_subscriptions").upsert({
+    telegram_user_id: prof.telegram_id,
+    plan_id: p.plan_id,
+    payment_status: "completed",
+    is_active: true,
+    subscription_start_date: now.toISOString(),
+    subscription_end_date: expiresAt,
+  }, { onConflict: "telegram_user_id" });
+
+  await supa.from("bot_users").update({
+    is_vip: true,
+    subscription_expires_at: expiresAt,
+  }).eq("id", prof.id);
+
+  if (prof.telegram_id) {
+    const msg = body.message ||
+      `✅ <b>VIP Activated</b>\nYour access is valid until <b>${
+        new Date(expiresAt!).toLocaleDateString()
+      }</b>.`;
+    await tgSend(botToken, String(prof.telegram_id), msg);
+  }
+
+  await supa.from("admin_logs").insert({
+    admin_telegram_id: adminId || "unknown",
+    action_type: "payment_approved",
+    action_description: `Payment ${p.id} approved; VIP until ${expiresAt}`,
+    affected_table: "bot_users",
+    affected_record_id: prof.id,
+    new_values: { is_vip: true, subscription_expires_at: expiresAt },
+  });
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      status: newStatus,
+      subscription_expires_at: expiresAt,
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/subscriptions-cron/index.ts
+++ b/supabase/functions/subscriptions-cron/index.ts
@@ -1,0 +1,92 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getEnv } from "../_shared/env.ts";
+
+function need(k: string) {
+  return getEnv(k as any);
+}
+
+async function tgSend(token: string, chatId: string, text: string) {
+  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+  }).catch(() => {});
+}
+
+serve(async (_req) => {
+  const url = need("SUPABASE_URL");
+  const svc = need("SUPABASE_SERVICE_ROLE_KEY");
+  const bot = need("TELEGRAM_BOT_TOKEN");
+  const supa = createClient(url, svc, { auth: { persistSession: false } });
+
+  const now = new Date();
+  const d7 = new Date(now);
+  d7.setDate(now.getDate() + 7);
+  const d1 = new Date(now);
+  d1.setDate(now.getDate() + 1);
+
+  let { data: soon7 } = await supa.rpc("get_users_expiring_between", {
+    start_ts: new Date(d7.setHours(0, 0, 0, 0)).toISOString(),
+    end_ts: new Date(d7.setHours(23, 59, 59, 999)).toISOString(),
+  }).catch(() => ({ data: [] as any[] }));
+  for (const u of soon7 || []) {
+    if (u.telegram_id) {
+      await tgSend(
+        bot,
+        String(u.telegram_id),
+        "⏰ <b>Reminder:</b> Your VIP expires in 7 days. Renew in the Mini App.",
+      );
+    }
+  }
+
+  let { data: soon1 } = await supa.rpc("get_users_expiring_between", {
+    start_ts: new Date(d1.setHours(0, 0, 0, 0)).toISOString(),
+    end_ts: new Date(d1.setHours(23, 59, 59, 999)).toISOString(),
+  }).catch(() => ({ data: [] as any[] }));
+  for (const u of soon1 || []) {
+    if (u.telegram_id) {
+      await tgSend(
+        bot,
+        String(u.telegram_id),
+        "⏰ <b>Final reminder:</b> Your VIP expires tomorrow. Renew to keep access.",
+      );
+    }
+  }
+
+  const { data: expired } = await supa.from("bot_users")
+    .select("id,telegram_id,subscription_expires_at")
+    .not("subscription_expires_at", "is", null)
+    .lte("subscription_expires_at", now.toISOString());
+  for (const u of expired || []) {
+    await supa.from("bot_users").update({ is_vip: false }).eq("id", u.id);
+    await supa.from("admin_logs").insert({
+      admin_telegram_id: "system",
+      action_type: "vip_expired",
+      action_description: `Auto-expire user ${u.id}`,
+      affected_table: "bot_users",
+      affected_record_id: u.id,
+      old_values: { subscription_expires_at: u.subscription_expires_at },
+      new_values: { is_vip: false },
+    });
+    if (u.telegram_id) {
+      await tgSend(
+        bot,
+        String(u.telegram_id),
+        "⚠️ <b>VIP expired.</b> Renew anytime from the Mini App.",
+      );
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      counts: {
+        reminded7: soon7?.length || 0,
+        reminded1: soon1?.length || 0,
+        expired: expired?.length || 0,
+      },
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -295,6 +295,24 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
         await notifyUser(chatId, JSON.stringify(info));
         break;
       }
+      case "/status": {
+        const supa = await getSupabase();
+        if (supa) {
+          const { data } = await supa
+            .from("bot_users")
+            .select("is_vip,subscription_expires_at")
+            .eq("telegram_id", chatId)
+            .maybeSingle();
+          const vip = data?.is_vip ? "VIP: active" : "VIP: inactive";
+          const expiry = data?.subscription_expires_at
+            ? `Expiry: ${
+              new Date(data.subscription_expires_at).toLocaleDateString()
+            }`
+            : "Expiry: none";
+          await notifyUser(chatId, `${vip}\n${expiry}`);
+        }
+        break;
+      }
       default:
         // Unsupported command; ignore silently
         break;

--- a/supabase/migrations/20250811_phase4_helpers.sql
+++ b/supabase/migrations/20250811_phase4_helpers.sql
@@ -1,0 +1,10 @@
+-- Optional RPC to find users expiring between two timestamps
+create or replace function public.get_users_expiring_between(start_ts timestamptz, end_ts timestamptz)
+returns table (id uuid, telegram_id text, subscription_expires_at timestamptz)
+language sql
+as $$
+  select id, telegram_id, subscription_expires_at
+  from public.bot_users
+  where subscription_expires_at is not null
+    and subscription_expires_at between start_ts and end_ts
+$$;


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Adds admin-review-payment Edge function (approve/reject with months override), subscriptions-cron (reminders + auto-expire), notifications via Telegram, and admin_logs writes. Includes optional RPC helper and docs.

------
https://chatgpt.com/codex/tasks/task_e_6899b7b0ee288322a2d2c12807d04cdc