### PR TITLE
feat(admin-ui): Phase 5 — in-app admin (queue, approve/reject, logs) via initData auth

### DIFF
--- a/apps/miniapp-react/src/components/admin/Tabs.tsx
+++ b/apps/miniapp-react/src/components/admin/Tabs.tsx
@@ -1,0 +1,13 @@
+import { NavLink } from 'react-router-dom';
+
+export default function AdminTabs() {
+  const base = "flex-1 px-3 py-2 rounded-md text-sm font-medium text-center";
+  const active = base + " bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900";
+  const inactive = base + " bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200";
+  return (
+    <div className="flex gap-2 mb-4">
+      <NavLink to="/admin/payments" className={({isActive}) => isActive ? active : inactive}>Payments</NavLink>
+      <NavLink to="/admin/logs" className={({isActive}) => isActive ? active : inactive}>Logs</NavLink>
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/routes/App.tsx
+++ b/apps/miniapp-react/src/routes/App.tsx
@@ -3,6 +3,8 @@ import Landing from '@/routes/Landing';
 import Dashboard from '@/routes/Dashboard';
 import Plans from '@/routes/Plans';
 import Checkout from '@/routes/Checkout';
+import AdminGate from '@/routes/admin/AdminGate';
+import Admin from '@/routes/admin';
 
 export default function App() {
   const loc = useLocation();
@@ -29,6 +31,7 @@ export default function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/plans" element={<Plans />} />
           <Route path="/checkout" element={<Checkout />} />
+          <Route path="/admin/*" element={<AdminGate><Admin /></AdminGate>} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/apps/miniapp-react/src/routes/admin/AdminGate.tsx
+++ b/apps/miniapp-react/src/routes/admin/AdminGate.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { useTelegram } from '@/shared/useTelegram';
+import { adminCheck } from '@/services/api';
+import { Navigate } from 'react-router-dom';
+
+export default function AdminGate({ children }: { children: React.ReactNode }) {
+  const { initData } = useTelegram();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (!initData) { setAllowed(false); return; }
+      const j = await adminCheck(initData);
+      setAllowed(!!j.ok);
+    })();
+  }, [initData]);
+
+  if (allowed === null) return <div className="card">Checking admin access…</div>;
+  if (!allowed) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}

--- a/apps/miniapp-react/src/routes/admin/Logs.tsx
+++ b/apps/miniapp-react/src/routes/admin/Logs.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useTelegram } from '@/shared/useTelegram';
+import { adminFetchLogs } from '@/services/api';
+
+export default function Logs() {
+  const { initData } = useTelegram();
+  const [items, setItems] = useState<any[]>([]);
+  useEffect(() => { (async () => {
+    const j = await adminFetchLogs(initData || "", 50, 0);
+    setItems(j.items || []);
+  })(); }, [initData]);
+
+  return (
+    <div className="space-y-2">
+      {items.map((r, i) => (
+        <div key={i} className="card">
+          <div className="text-xs opacity-70">{new Date(r.created_at).toLocaleString()}</div>
+          <div className="font-medium">{r.action_type}</div>
+          <div className="text-sm opacity-80">{r.action_description}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/routes/admin/Payments.tsx
+++ b/apps/miniapp-react/src/routes/admin/Payments.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useTelegram } from '@/shared/useTelegram';
+import { adminListPending, adminActOnPayment } from '@/services/api';
+
+export default function Payments() {
+  const { initData, haptic } = useTelegram();
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    setLoading(true);
+    const j = await adminListPending(initData || "", 50, 0);
+    setItems(j.items || []);
+    setLoading(false);
+  }
+  useEffect(() => { load(); }, [initData]);
+
+  async function act(id: string, decision: "approve"|"reject") {
+    const j = await adminActOnPayment(initData || "", id, decision);
+    if (j?.ok) { haptic('medium'); await load(); }
+  }
+
+  if (loading) return <div className="card">Loading queue…</div>;
+
+  return (
+    <div className="space-y-3">
+      {items.length === 0 && <div className="card">No pending payments.</div>}
+      {items.map((p) => (
+        <div key={p.id} className="card grid gap-2">
+          <div className="text-sm opacity-70">{new Date(p.created_at).toLocaleString()}</div>
+          <div className="font-medium">{p.plan} • {p.months ?? "?"} mo</div>
+          <div className="text-xs opacity-70">TG: {p.telegram_id ?? "-"}</div>
+          {p.receipt_url && <img src={p.receipt_url} alt="receipt" className="rounded-lg w-full max-h-72 object-contain" />}
+          <div className="flex gap-2">
+            <button onClick={() => act(p.id, "approve")} className="btn bg-emerald-600 text-white">Approve</button>
+            <button onClick={() => act(p.id, "reject")}  className="btn bg-rose-600 text-white">Reject</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/routes/admin/index.tsx
+++ b/apps/miniapp-react/src/routes/admin/index.tsx
@@ -1,0 +1,17 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Payments from './Payments';
+import Logs from './Logs';
+import AdminTabs from '@/components/admin/Tabs';
+
+export default function Admin() {
+  return (
+    <div className="space-y-4">
+      <AdminTabs />
+      <Routes>
+        <Route path="payments" element={<Payments />} />
+        <Route path="logs" element={<Logs />} />
+        <Route index element={<Navigate to="payments" replace />} />
+      </Routes>
+    </div>
+  );
+}

--- a/apps/miniapp-react/src/services/api.ts
+++ b/apps/miniapp-react/src/services/api.ts
@@ -149,3 +149,25 @@ export async function submitReceipt(
   });
   return r.ok;
 }
+
+
+export async function adminCheck(initData: string) {
+  const u = functionUrl('admin-check'); if (!u) return { ok:false };
+  const r = await fetch(u, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ initData }) });
+  return r.json();
+}
+export async function adminListPending(initData: string, limit=25, offset=0) {
+  const u = functionUrl('admin-list-pending'); if (!u) return { ok:false, items:[] };
+  const r = await fetch(u, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ initData, limit, offset }) });
+  return r.json();
+}
+export async function adminActOnPayment(initData: string, payment_id: string, decision: "approve"|"reject", months?: number, message?: string) {
+  const u = functionUrl('admin-act-on-payment'); if (!u) return { ok:false };
+  const r = await fetch(u, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ initData, payment_id, decision, months, message }) });
+  return r.json();
+}
+export async function adminFetchLogs(initData: string, limit=20, offset=0) {
+  const u = functionUrl('admin-logs'); if (!u) return { ok:false, items:[] };
+  const r = await fetch(u, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ initData, limit, offset }) });
+  return r.json();
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,6 +29,10 @@
     "edge:deploy:uploadurl": "npx supabase functions deploy receipt-upload-url",
     "edge:deploy:receipt": "npx supabase functions deploy receipt-submit",
     "edge:deploy:review": "npx supabase functions deploy admin-review-payment",
-    "edge:deploy:cron": "npx supabase functions deploy subscriptions-cron"
+    "edge:deploy:cron": "npx supabase functions deploy subscriptions-cron",
+    "edge:deploy:admin-check": "npx supabase functions deploy admin-check",
+    "edge:deploy:admin-list": "npx supabase functions deploy admin-list-pending",
+    "edge:deploy:admin-act": "npx supabase functions deploy admin-act-on-payment",
+    "edge:deploy:admin-logs": "npx supabase functions deploy admin-logs"
   }
 }

--- a/docs/PHASE_5_ADMIN_UI.md
+++ b/docs/PHASE_5_ADMIN_UI.md
@@ -1,0 +1,6 @@
+# Phase 5 – Admin UI
+
+- Admin auth = Telegram initData + allowlist.
+- No secrets in client.
+- Endpoints: admin-check, admin-list-pending, admin-act-on-payment, admin-logs.
+- Receipt previews use short-lived signed URLs.

--- a/supabase/functions/_shared/telegram.ts
+++ b/supabase/functions/_shared/telegram.ts
@@ -1,0 +1,46 @@
+export type TgUser = { id: number; username?: string; first_name?: string; last_name?: string };
+
+function toHex(buf: ArrayBuffer) {
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, "0")).join("");
+}
+async function hmacSHA256(key: CryptoKey, data: string) {
+  const enc = new TextEncoder();
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+  return toHex(sig);
+}
+async function importHmacKeyFromToken(token: string) {
+  const enc = new TextEncoder();
+  const secretKey = await crypto.subtle.digest("SHA-256", enc.encode(token));
+  return crypto.subtle.importKey("raw", secretKey, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+}
+
+/** Verifies initData and returns safe user if valid + not stale. */
+export async function verifyInitDataAndGetUser(initData: string, windowSec = 900): Promise<TgUser | null> {
+  if (!initData) return null;
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!token) throw new Error("Missing TELEGRAM_BOT_TOKEN");
+  const key = await importHmacKeyFromToken(token);
+
+  const params = new URLSearchParams(initData);
+  const hash = params.get("hash") || "";
+  params.delete("hash");
+  const dataCheckString = Array.from(params.entries()).map(([k, v]) => `${k}=${v}`).sort().join("\n");
+  const sig = await hmacSHA256(key, dataCheckString);
+  if (sig !== hash) return null;
+
+  // Optional freshness check
+  const auth = Number(params.get("auth_date") || "0");
+  const age = Math.floor(Date.now() / 1000) - auth;
+  if (windowSec > 0 && (isNaN(auth) || age > windowSec)) return null;
+
+  const userJson = params.get("user");
+  if (!userJson) return null;
+  try { return JSON.parse(decodeURIComponent(userJson)) as TgUser; } catch { return null; }
+}
+
+/** Checks if a Telegram user id is in TELEGRAM_ADMIN_IDS allowlist. */
+export function isAdmin(tgId: number | string): boolean {
+  const raw = (Deno.env.get("TELEGRAM_ADMIN_IDS") || "").split(",").map(s => s.trim()).filter(Boolean);
+  const set = new Set(raw);
+  return set.has(String(tgId));
+}

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -1,0 +1,75 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+
+type Body = { initData: string; payment_id: string; decision: "approve"|"reject"; months?: number; message?: string };
+
+async function tgSend(token: string, chatId: string, text: string) {
+  await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST", headers: { "content-type":"application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" })
+  }).catch(()=>{});
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  let body: Body; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
+
+  const u = await verifyInitDataAndGetUser(body.initData || "");
+  if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
+
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const bot = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
+  const supa = createClient(url, svc, { auth: { persistSession: false } });
+
+  // Load payment + user + plan
+  const { data: p } = await supa.from("payments").select("id,status,user_id,plan_id,amount,currency,created_at").eq("id", body.payment_id).maybeSingle();
+  if (!p) return new Response("Payment not found", { status: 404 });
+  const { data: user } = await supa.from("bot_users").select("id,telegram_id,subscription_expires_at,is_vip").eq("id", p.user_id).maybeSingle();
+  if (!user) return new Response("User not found", { status: 404 });
+
+  if (body.decision === "reject") {
+    await supa.from("payments").update({ status: "rejected" }).eq("id", p.id);
+    if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `❌ <b>Payment Rejected</b>\n${body.message || "Please contact support."}`);
+    await supa.from("admin_logs").insert({
+      admin_telegram_id: String(u.id),
+      action_type: "payment_rejected",
+      action_description: `Payment ${p.id} rejected`,
+      affected_table: "payments",
+      affected_record_id: p.id,
+      new_values: { status: "rejected" }
+    });
+    return new Response(JSON.stringify({ ok:true, status:"rejected" }), { headers: { "content-type":"application/json" }});
+  }
+
+  // approve
+  let months = Number.isFinite(body.months) ? Number(body.months) : null;
+  if (!months) {
+    const { data: plan } = await supa.from("subscription_plans").select("duration_months,is_lifetime").eq("id", p.plan_id).maybeSingle();
+    months = plan?.is_lifetime ? 1200 : (plan?.duration_months || 1);
+  }
+
+  const now = new Date();
+  const base = user.subscription_expires_at && new Date(user.subscription_expires_at) > now ? new Date(user.subscription_expires_at) : now;
+  const next = new Date(base); next.setMonth(next.getMonth() + (months || 1));
+  const expiresAt = next.toISOString();
+
+  await supa.from("payments").update({ status: "completed" }).eq("id", p.id);
+  await supa.from("user_subscriptions").upsert({
+    telegram_user_id: user.telegram_id, plan_id: p.plan_id, payment_status: "completed",
+    is_active: true, subscription_start_date: now.toISOString(), subscription_end_date: expiresAt
+  }, { onConflict: "telegram_user_id" });
+  await supa.from("bot_users").update({ is_vip: true, subscription_expires_at: expiresAt }).eq("id", user.id);
+
+  if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `✅ <b>VIP Activated</b>\nValid until <b>${new Date(expiresAt).toLocaleDateString()}</b>.`);
+  await supa.from("admin_logs").insert({
+    admin_telegram_id: String(u.id),
+    action_type: "payment_approved",
+    action_description: `Payment ${p.id} approved; VIP until ${expiresAt}`,
+    affected_table: "bot_users", affected_record_id: user.id,
+    new_values: { is_vip: true, subscription_expires_at: expiresAt }
+  });
+
+  return new Response(JSON.stringify({ ok:true, status:"completed", subscription_expires_at: expiresAt }), { headers: { "content-type":"application/json" }});
+});

--- a/supabase/functions/admin-check/index.ts
+++ b/supabase/functions/admin-check/index.ts
@@ -1,0 +1,10 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+
+serve(async (req) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  let body: { initData?: string }; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
+  const u = await verifyInitDataAndGetUser(body.initData || "");
+  const ok = !!(u && isAdmin(u.id));
+  return new Response(JSON.stringify({ ok, user_id: u?.id ?? null }), { headers: { "content-type":"application/json" }});
+});

--- a/supabase/functions/admin-list-pending/index.ts
+++ b/supabase/functions/admin-list-pending/index.ts
@@ -1,0 +1,51 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  let body: { initData?: string; limit?: number; offset?: number }; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
+
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const srv = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supa = createClient(url, srv, { auth: { persistSession: false } });
+
+  const u = await verifyInitDataAndGetUser(body.initData || "");
+  if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
+
+  const limit = Math.min(Math.max(body.limit ?? 25, 1), 100);
+  const offset = Math.max(body.offset ?? 0, 0);
+
+  // Pull payments pending + join plan & user
+  const { data: rows, error } = await supa
+    .from("payments")
+    .select("id,created_at,user_id,plan_id,amount,currency,status,webhook_data, bot_users!inner(telegram_id), subscription_plans!inner(name,duration_months)")
+    .eq("status", "pending")
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) return new Response(JSON.stringify({ ok:false, error: error.message }), { status: 500 });
+
+  // For each receipt path, create short-lived signed URL for preview
+  const out = [];
+  for (const r of rows || []) {
+    let signed_url: string | null = null;
+    const bucket = r.webhook_data?.storage_bucket || "receipts";
+    const path   = r.webhook_data?.storage_path || null;
+    if (path) {
+      const { data: signed } = await supa.storage.from(bucket).createSignedUrl(path, 600); // 10 min
+      signed_url = signed?.signedUrl || null;
+    }
+    out.push({
+      id: r.id,
+      created_at: r.created_at,
+      telegram_id: r.bot_users?.telegram_id || null,
+      plan: r.subscription_plans?.name || null,
+      months: r.subscription_plans?.duration_months || null,
+      amount: r.amount, currency: r.currency,
+      receipt_url: signed_url
+    });
+  }
+
+  return new Response(JSON.stringify({ ok:true, items: out }), { headers: { "content-type":"application/json" }});
+});

--- a/supabase/functions/admin-logs/index.ts
+++ b/supabase/functions/admin-logs/index.ts
@@ -1,0 +1,26 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+
+serve(async (req) => {
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+  let body: { initData: string; limit?: number; offset?: number }; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
+
+  const u = await verifyInitDataAndGetUser(body.initData || "");
+  if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
+
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supa = createClient(url, svc, { auth: { persistSession: false } });
+
+  const limit = Math.min(Math.max(body.limit ?? 20, 1), 100);
+  const offset = Math.max(body.offset ?? 0, 0);
+
+  const { data, error } = await supa.from("admin_logs")
+    .select("created_at,admin_telegram_id,action_type,action_description,affected_table,affected_record_id")
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) return new Response(JSON.stringify({ ok:false, error: error.message }), { status: 500 });
+  return new Response(JSON.stringify({ ok:true, items: data }), { headers: { "content-type":"application/json" }});
+});


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Adds admin UI to the Mini App with server-verified initData auth (no client secrets). New endpoints for pending list, approve/reject, and logs. Receipt previews via signed URLs.

------
https://chatgpt.com/codex/tasks/task_e_6899b9c0df908322b304e86af416bbf8