### PR TITLE
feat: add miniapp smoke diagnostics

### DIFF
--- a/apps/miniapp-react/src/routes/App.tsx
+++ b/apps/miniapp-react/src/routes/App.tsx
@@ -1,21 +1,21 @@
-import { Route, Routes, Navigate, Link, useLocation } from 'react-router-dom';
-import Landing from '@/routes/Landing';
-import Dashboard from '@/routes/Dashboard';
-import Plans from '@/routes/Plans';
-import Checkout from '@/routes/Checkout';
-import AdminGate from '@/routes/admin/AdminGate';
-import Admin from '@/routes/admin';
+import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
+import Landing from "@/routes/Landing";
+import Dashboard from "@/routes/Dashboard";
+import Plans from "@/routes/Plans";
+import Checkout from "@/routes/Checkout";
+import Diag from "@/routes/Diag";
+import AdminGate from "@/routes/admin/AdminGate";
+import Admin from "@/routes/admin";
 
 export default function App() {
   const loc = useLocation();
-  const page =
-    loc.pathname === '/dashboard'
-      ? 'Dashboard'
-      : loc.pathname === '/plans'
-      ? 'Plans'
-      : loc.pathname === '/checkout'
-      ? 'Checkout'
-      : 'Home';
+  const page = loc.pathname === "/dashboard"
+    ? "Dashboard"
+    : loc.pathname === "/plans"
+    ? "Plans"
+    : loc.pathname === "/checkout"
+    ? "Checkout"
+    : "Home";
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 text-slate-900 dark:text-slate-100">
@@ -31,7 +31,15 @@ export default function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/plans" element={<Plans />} />
           <Route path="/checkout" element={<Checkout />} />
-          <Route path="/admin/*" element={<AdminGate><Admin /></AdminGate>} />
+          <Route path="/diag" element={<Diag />} />
+          <Route
+            path="/admin/*"
+            element={
+              <AdminGate>
+                <Admin />
+              </AdminGate>
+            }
+          />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/apps/miniapp-react/src/routes/Diag.tsx
+++ b/apps/miniapp-react/src/routes/Diag.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useTelegram } from "@/shared/useTelegram";
+import { functionUrl } from "@/lib/edge";
+
+export default function Diag() {
+  const { initData, user } = useTelegram();
+  // deno-lint-ignore no-explicit-any
+  const [out, setOut] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function run() {
+    setLoading(true);
+    try {
+      const url = functionUrl("miniapp-smoke");
+      const r = await fetch(url!, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          initData,
+          telegram_id: user?.id ? String(user.id) : undefined,
+        }),
+      });
+      const j = await r.json();
+      setOut(j);
+    } catch (e) {
+      setOut({ ok: false, error: String(e) });
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    run();
+  }, [initData, user?.id]);
+
+  return (
+    <section className="rounded-2xl shadow p-5 bg-white/80 dark:bg-slate-800/80 backdrop-blur space-y-3">
+      <h2 className="text-xl font-semibold">Diagnostics</h2>
+      <div className="text-sm opacity-80">
+        Checks reachability, initData verification, and VIP status.
+      </div>
+      <button
+        type="button"
+        onClick={run}
+        className="px-3 py-2 rounded-xl bg-blue-600 text-white text-sm shadow hover:bg-blue-700 disabled:opacity-60"
+        disabled={loading}
+      >
+        {loading ? "Running…" : "Re-run checks"}
+      </button>
+      <pre className="text-xs bg-black/70 text-emerald-100 p-3 rounded-xl overflow-auto max-h-96">
+        {out ? JSON.stringify(out, null, 2) : "…"}
+      </pre>
+    </section>
+  );
+}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -35,6 +35,7 @@
     "edge:deploy:admin-act": "npx supabase functions deploy admin-act-on-payment",
     "edge:deploy:admin-logs": "npx supabase functions deploy admin-logs",
     "edge:deploy:analytics": "npx supabase functions deploy analytics-collector",
-    "edge:deploy:ops": "npx supabase functions deploy ops-health"
+    "edge:deploy:ops": "npx supabase functions deploy ops-health",
+    "edge:deploy:smoke": "npx supabase functions deploy miniapp-smoke"
   }
 }

--- a/supabase/functions/miniapp-smoke/index.ts
+++ b/supabase/functions/miniapp-smoke/index.ts
@@ -1,0 +1,93 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+const must = (k: string) =>
+  Deno.env.get(k) || (() => {
+    throw new Error(`Missing ${k}`);
+  })();
+
+async function headOK(url: string) {
+  try {
+    const r = await fetch(url, { method: "HEAD" });
+    return r.ok || (r.status >= 200 && r.status < 400);
+  } catch {
+    return false;
+  }
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  // deno-lint-ignore no-explicit-any
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch { /* ignore */ }
+  const initData = body.initData as string | undefined;
+  const telegram_id = body.telegram_id as string | undefined;
+
+  const mini = Deno.env.get("MINI_APP_URL") ||
+    `https://${(Deno.env.get("SUPABASE_URL")
+      ? new URL(must("SUPABASE_URL")).hostname.split(".")[0]
+      : must("SUPABASE_PROJECT_ID"))}.functions.supabase.co/miniapp/`;
+
+  const checks: Record<string, unknown> = { ok: true, miniAppUrl: mini };
+
+  // 1) Reachability of miniapp host
+  checks.reach = await headOK(mini);
+  if (!checks.reach) checks.ok = false;
+
+  // 2) Verify initData (if provided)
+  if (initData) {
+    try {
+      const r = await fetch(
+        `https://${(Deno.env.get("SUPABASE_URL")
+          ? new URL(must("SUPABASE_URL")).hostname.split(".")[0]
+          : must(
+            "SUPABASE_PROJECT_ID",
+          ))}.functions.supabase.co/verify-initdata`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ initData }),
+        },
+      );
+      const j = await r.json().catch(() => ({}));
+      checks.verify = { status: r.status, ok: !!j?.ok };
+      if (!j?.ok) checks.ok = false;
+    } catch (e) {
+      checks.verify = { error: String(e) };
+      checks.ok = false;
+    }
+  } else {
+    checks.verify = { skipped: true };
+  }
+
+  // 3) VIP status (if telegram_id provided)
+  if (telegram_id) {
+    try {
+      const r = await fetch(
+        `https://${(Deno.env.get("SUPABASE_URL")
+          ? new URL(must("SUPABASE_URL")).hostname.split(".")[0]
+          : must("SUPABASE_PROJECT_ID"))}.functions.supabase.co/miniapp-health`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ telegram_id }),
+        },
+      );
+      const j = await r.json().catch(() => ({}));
+      checks.health = { status: r.status, ok: !!j?.ok, vip: j?.vip ?? null };
+      if (!j?.ok) checks.ok = false;
+    } catch (e) {
+      checks.health = { error: String(e) };
+      checks.ok = false;
+    }
+  } else {
+    checks.health = { skipped: true };
+  }
+
+  return new Response(JSON.stringify(checks, null, 2), {
+    headers: { "content-type": "application/json" },
+    status: checks.ok ? 200 : 500,
+  });
+});


### PR DESCRIPTION
## Summary
- add edge function `miniapp-smoke` for reachability, initData, and VIP health checks
- add React diagnostics page and route for miniapp
- wire up deploy task for smoke endpoint

## Testing
- `deno fmt supabase/functions/miniapp-smoke/index.ts apps/miniapp-react/src/routes/Diag.tsx apps/miniapp-react/src/routes/App.tsx deno.jsonc`
- `deno lint supabase/functions/miniapp-smoke/index.ts apps/miniapp-react/src/routes/Diag.tsx apps/miniapp-react/src/routes/App.tsx deno.jsonc`
- `deno task -c deno.jsonc miniapp:deploy` *(fails: Access token not provided)*
- `deno task -c deno.jsonc edge:deploy:smoke` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6899befa704c8322acb86fab3f57c233