### PR TITLE
feat: add chat menu and miniapp audit utilities

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -36,6 +36,9 @@
     "edge:deploy:admin-logs": "npx supabase functions deploy admin-logs",
     "edge:deploy:analytics": "npx supabase functions deploy analytics-collector",
     "edge:deploy:ops": "npx supabase functions deploy ops-health",
-    "edge:deploy:smoke": "npx supabase functions deploy miniapp-smoke"
+    "edge:deploy:smoke": "npx supabase functions deploy miniapp-smoke",
+    "tg:menu:get": "deno run -A scripts/tg-chat-menu.ts get",
+    "tg:menu:set": "deno run -A scripts/tg-chat-menu.ts set",
+    "miniapp:audit": "deno run -A scripts/miniapp-audit.ts"
   }
 }

--- a/scripts/miniapp-audit.ts
+++ b/scripts/miniapp-audit.ts
@@ -1,0 +1,14 @@
+// Checks that MINI_APP_URL returns HTML and looks like your SPA.
+const url = Deno.env.get("MINI_APP_URL");
+if (!url) throw new Error("MINI_APP_URL missing");
+const u = url.endsWith("/") ? url : url + "/";
+const r = await fetch(u);
+const text = await r.text();
+const ok = r.ok && /<html|<div[^>]+id=["']root["']/i.test(text);
+console.log(
+  JSON.stringify(
+    { url: u, status: r.status, ok, snippet: text.slice(0, 300) },
+    null,
+    2,
+  ),
+);

--- a/scripts/tg-chat-menu.ts
+++ b/scripts/tg-chat-menu.ts
@@ -1,0 +1,37 @@
+// deno run -A scripts/tg-chat-menu.ts get|set [url]
+const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+if (!token) throw new Error("TELEGRAM_BOT_TOKEN missing");
+
+const base = `https://api.telegram.org/bot${token}`;
+
+async function call(method: string, body?: unknown) {
+  const r = await fetch(`${base}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const j = await r.json().catch(() => ({}));
+  console.log(method, r.status, JSON.stringify(j, null, 2));
+  return j;
+}
+
+const [mode, urlArg] = Deno.args;
+if (mode === "get") {
+  await call("getChatMenuButton", {});
+} else if (mode === "set") {
+  if (!urlArg) {
+    throw new Error("Usage: deno run -A scripts/tg-chat-menu.ts set <url>");
+  }
+  await call("setChatMenuButton", {
+    menu_button: {
+      type: "web_app",
+      text: "Open VIP Mini App",
+      web_app: { url: urlArg },
+    },
+  });
+  await call("getChatMenuButton", {});
+} else {
+  console.log(
+    "Usage:\n  deno run -A scripts/tg-chat-menu.ts get\n  deno run -A scripts/tg-chat-menu.ts set <url>",
+  );
+}

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -46,7 +46,13 @@ const TYPE = (p: string) =>
     ? "image/webp"
     : "application/octet-stream";
 
-serve(async (req) => {
+serve((req) => {
+  console.log(
+    "miniapp hit",
+    new Date().toISOString(),
+    new URL(req.url).pathname,
+    req.headers.get("user-agent") || "",
+  );
   const url = new URL(req.url);
   if (
     url.pathname === "/" || url.pathname === "/miniapp" ||


### PR DESCRIPTION
## Summary
- add script to inspect or set Telegram chat menu button
- log each miniapp request for easier debugging
- provide miniapp audit script with corresponding deno tasks

## Testing
- `npx supabase functions deploy miniapp` *(fails: Access token not provided)*
- `npx supabase link --project-ref qeejuomcapbdlhnjqjcc` *(fails: Access token not provided)*
- `MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/ deno run -A --no-npm --unsafely-ignore-certificate-errors=qeejuomcapbdlhnjqjcc.functions.supabase.co scripts/miniapp-audit.ts`
- `npx supabase functions logs --project-ref qeejuomcapbdlhnjqjcc --since 10m` *(unknown flag: --project-ref)*
- `TELEGRAM_BOT_TOKEN=TEST deno run -A --no-npm --unsafely-ignore-certificate-errors=api.telegram.org scripts/tg-chat-menu.ts set "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/?v=2025-08-11-1"`


------
https://chatgpt.com/codex/tasks/task_e_6899c32081e08322b8cf2aca45cfd381