### PR TITLE
feat: auto verify payments

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -45,7 +45,10 @@
     "edge:deploy:ref": "npx supabase functions deploy referral-link",
     "edge:deploy:broadcast": "npx supabase functions deploy broadcast-dispatch && npx supabase functions deploy broadcast-cron",
     "edge:deploy:funnel": "npx supabase functions deploy funnel-track",
-    "edge:deploy:security": "npx supabase functions deploy admin-bans && npx supabase functions deploy data-retention-cron && npx supabase functions deploy rotate-webhook-secret"
+    "edge:deploy:security": "npx supabase functions deploy admin-bans && npx supabase functions deploy data-retention-cron && npx supabase functions deploy rotate-webhook-secret",
+    "edge:deploy:ocr": "npx supabase functions deploy receipt-ocr",
+    "edge:deploy:auto": "npx supabase functions deploy payments-auto-review",
+    "edge:deploy:binance": "npx supabase functions deploy binancepay-webhook"
   }
 }
 // Schedules:
@@ -53,3 +56,5 @@
 // supabase functions schedule create "10 3 * * *" data-retention-cron
 // Optional monthly rotation (manual trigger recommended first time)
 // supabase functions schedule create "0 2 1 * *" rotate-webhook-secret
+// Auto-review: every 10 minutes
+// supabase functions schedule create "*/10 * * * *" payments-auto-review

--- a/docs/PHASE_10_AUTOVERIFY.md
+++ b/docs/PHASE_10_AUTOVERIFY.md
@@ -1,0 +1,27 @@
+# Phase 10: Auto-Verify Payments
+
+## Edge Functions
+
+- **/receipt-ocr** — input `{ payment_id }`, analyzes the stored receipt image
+  with OpenAI and writes results to `payments.webhook_data.ocr`.
+- **/payments-auto-review** — scans recent pending payments and auto-approves
+  when rules pass; logs `admin_logs` and reuses Phase 4 approver endpoint.
+- **/binancepay-webhook** — stubbed Binance Pay webhook (disabled by default)
+  until signature verification is implemented.
+
+## Verification Rules
+
+Defaults stored in `bot_settings`:
+
+- `AMOUNT_TOLERANCE`: 0.05 (5% difference allowed)
+- `WINDOW_SECONDS`: 7200 (2‑hour receipt time window)
+
+A payment is approved when:
+
+1. OCR confidence ≥ 0.7
+2. Amount within tolerance
+3. Currency matches
+4. Receipt date within time window
+
+Enable Binance hooks by setting `BINANCE_ENABLED=true` after implementing
+signature checks.

--- a/supabase/functions/binancepay-webhook/index.ts
+++ b/supabase/functions/binancepay-webhook/index.ts
@@ -1,0 +1,48 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  if (Deno.env.get("BINANCE_ENABLED") !== "true") {
+    return new Response("Disabled", { status: 403 });
+  }
+
+  // NOTE: Implement Binance signature verification here before trusting payload.
+  // Placeholder only — do NOT auto-approve without real verification!
+
+  const body = await req.json().catch(() => ({}));
+  // Example: locate payment by payment_provider_id from your checkout-init step
+  const providerId = body?.merchantTradeNo || body?.prepayId || null;
+
+  const supa = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false } },
+  );
+
+  if (providerId) {
+    const { data: rows } = await supa.from("payments").select("id").eq(
+      "payment_provider_id",
+      providerId,
+    ).limit(1);
+    if (rows && rows[0]) {
+      await supa.from("payments").update({
+        status: "completed",
+        webhook_data: { ...(body || {}), source: "binance_webhook" },
+      }).eq("id", rows[0].id);
+      await supa.from("admin_logs").insert({
+        admin_telegram_id: "system",
+        action_type: "provider_webhook",
+        action_description: `Binance webhook completed payment ${rows[0].id}`,
+        affected_table: "payments",
+        affected_record_id: rows[0].id,
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" },
+  });
+});

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -1,0 +1,142 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const need = (k: string) =>
+  Deno.env.get(k) || (() => {
+    throw new Error(`Missing env ${k}`);
+  })();
+
+async function approve(supa: any, paymentId: string, monthsOverride?: number) {
+  // Reuse Phase 4 admin flow by calling the endpoint (keeps logic in one place)
+  const admin = need("ADMIN_API_SECRET");
+  const ref = new URL(need("SUPABASE_URL")).hostname.split(".")[0];
+  const url = `https://${ref}.functions.supabase.co/admin-review-payment`;
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", "X-Admin-Secret": admin },
+    body: JSON.stringify({
+      payment_id: paymentId,
+      decision: "approve",
+      months: monthsOverride,
+      message: "✅ Auto-verified payment",
+    }),
+  });
+  return { ok: r.ok, j: await r.json().catch(() => ({})) };
+}
+
+function num(x: any) {
+  const n = Number(x);
+  return isFinite(n) ? n : null;
+}
+
+serve(async (req) => {
+  if (req.method !== "POST" && req.method !== "GET") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const supa = createClient(
+    need("SUPABASE_URL"),
+    need("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false } },
+  );
+
+  // Pull tolerance & window from bot_settings (fallbacks)
+  const { data: tolRow } = await supa.from("bot_settings").select(
+    "content_value",
+  ).eq("content_key", "AMOUNT_TOLERANCE").maybeSingle();
+  const tol = num(tolRow?.content_value) ?? 0.05; // 5%
+  const { data: winRow } = await supa.from("bot_settings").select(
+    "content_value",
+  ).eq("content_key", "WINDOW_SECONDS").maybeSingle();
+  const win = Number(winRow?.content_value ?? 7200);
+
+  // Find recent pending with receipts
+  const sinceIso = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+  const { data: pendings } = await supa.from("payments")
+    .select(
+      "id,plan_id,amount,currency,payment_method,created_at,webhook_data, status",
+    )
+    .eq("status", "pending").gte("created_at", sinceIso).limit(50);
+
+  const results: any[] = [];
+
+  for (const p of pendings || []) {
+    const ocr = p.webhook_data?.ocr;
+    const hasReceipt = !!p.webhook_data?.storage_path;
+
+    // If bank_transfer and has receipt but no OCR yet, trigger OCR once and skip for now
+    if (p.payment_method === "bank_transfer" && hasReceipt && !ocr) {
+      const ref = new URL(need("SUPABASE_URL")).hostname.split(".")[0];
+      await fetch(`https://${ref}.functions.supabase.co/receipt-ocr`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ payment_id: p.id }),
+      }).catch(() => {});
+      results.push({ id: p.id, action: "queued_ocr" });
+      continue;
+    }
+
+    // Evaluate rules
+    let pass = false;
+    let reason = "";
+
+    if (p.payment_method === "bank_transfer" && ocr) {
+      const amt = num(ocr.amount);
+      const currency = (ocr.currency || "").toUpperCase();
+      // Expected price/currency from plan
+      const { data: plan } = await supa.from("subscription_plans").select(
+        "price,currency",
+      ).eq("id", p.plan_id).maybeSingle();
+      const expAmt = num(plan?.price ?? p.amount);
+      const expCur = (plan?.currency ?? p.currency ?? "").toUpperCase();
+      const within = (amt != null && expAmt != null)
+        ? Math.abs(amt - expAmt) <= (expAmt * tol + 0.01)
+        : false;
+      const curOK = currency && expCur ? (currency === expCur) : true;
+
+      // Time window check (receipt date close to created_at)
+      let timeOK = true;
+      if (ocr.date) {
+        const rcpt = new Date(String(ocr.date));
+        const created = new Date(p.created_at);
+        timeOK = Math.abs(rcpt.getTime() - created.getTime()) <= win * 1000;
+      }
+
+      pass = Boolean((ocr.confidence ?? 0) >= 0.7 && within && curOK && timeOK);
+      reason = pass
+        ? "rules_ok"
+        : `fail(conf=${ocr.confidence},within=${within},cur=${curOK},time=${timeOK})`;
+    }
+
+    // Optional: provider hooks (Binance Pay) — only if enabled and we have provider id
+    if (
+      !pass && Deno.env.get("BINANCE_ENABLED") === "true" &&
+      p.payment_method === "binance_pay" && p.payment_provider_id
+    ) {
+      // TODO: Implement live status check using BINANCE_API_KEY/SECRET and provider order id (p.payment_provider_id)
+      // If confirmed paid -> pass=true; reason="binance_ok"
+    }
+
+    if (pass) {
+      await supa.from("admin_logs").insert({
+        admin_telegram_id: "system",
+        action_type: "auto_approve",
+        action_description:
+          `Auto-approved payment ${p.id} via ${p.payment_method} (${reason})`,
+        affected_table: "payments",
+        affected_record_id: p.id,
+      });
+      const ok = await approve(supa, p.id);
+      results.push({ id: p.id, action: "approved", ok: ok.ok });
+    } else {
+      results.push({
+        id: p.id,
+        action: ocr ? `held_${reason}` : "waiting_ocr",
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true, results }), {
+    headers: { "content-type": "application/json" },
+  });
+});

--- a/supabase/functions/receipt-ocr/index.ts
+++ b/supabase/functions/receipt-ocr/index.ts
@@ -1,0 +1,110 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type Body = { payment_id: string };
+
+const need = (k: string) =>
+  Deno.env.get(k) || (() => {
+    throw new Error(`Missing env ${k}`);
+  })();
+
+async function openAiExtract(
+  imageUrl: string,
+  hints: Record<string, string | number>,
+) {
+  const api = need("OPENAI_API_KEY");
+  // Ask for strict JSON back
+  const sys =
+    "You are an extraction engine. Return strict JSON with keys: amount (number), currency (string, ISO code), date (yyyy-mm-dd), reference (string|null), payer_name (string|null), bank_name (string|null), confidence (0..1). If uncertain, set fields null and lower confidence.";
+  const usr = [
+    {
+      type: "text",
+      text: `Extract fields from this payment receipt. Hints: ${
+        JSON.stringify(hints)
+      }`,
+    },
+    { type: "image_url", image_url: { url: imageUrl } },
+  ];
+
+  const r = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "authorization": `Bearer ${api}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      response_format: { type: "json_object" },
+      messages: [{ role: "system", content: sys }, {
+        role: "user",
+        content: usr,
+      }],
+    }),
+  });
+  const j = await r.json();
+  try {
+    return JSON.parse(j.choices?.[0]?.message?.content ?? "{}");
+  } catch {
+    return { confidence: 0 };
+  }
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+
+  const supa = createClient(
+    need("SUPABASE_URL"),
+    need("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false } },
+  );
+
+  // Load payment + plan + receipt path
+  const { data: p } = await supa.from("payments")
+    .select(
+      "id, plan_id, amount, currency, payment_method, webhook_data, created_at",
+    )
+    .eq("id", body.payment_id).maybeSingle();
+  if (!p) return new Response("Payment not found", { status: 404 });
+
+  const path = p.webhook_data?.storage_path;
+  const bucket = p.webhook_data?.storage_bucket || "receipts";
+  if (!path) return new Response("No receipt on file", { status: 400 });
+
+  // Get a signed URL for the image
+  const { data: signed, error: sErr } = await supa.storage.from(bucket)
+    .createSignedUrl(path, 600);
+  if (sErr || !signed?.signedUrl) {
+    return new Response("Cannot sign receipt URL", { status: 500 });
+  }
+
+  // Optional plan lookup (to hint expected price/currency)
+  const { data: plan } = await supa.from("subscription_plans").select(
+    "price,currency",
+  ).eq("id", p.plan_id).maybeSingle();
+
+  // OCR via OpenAI (image URL)
+  const result = await openAiExtract(signed.signedUrl, {
+    expected_amount: plan?.price ?? p.amount ?? "",
+    expected_currency: plan?.currency ?? p.currency ?? "",
+  });
+
+  // Persist raw analysis into webhook_data. Non-destructive upsert.
+  const merged = {
+    ...(p.webhook_data || {}),
+    ocr: result,
+    ocr_at: new Date().toISOString(),
+  };
+  await supa.from("payments").update({ webhook_data: merged }).eq("id", p.id);
+
+  return new Response(JSON.stringify({ ok: true, ocr: result }), {
+    headers: { "content-type": "application/json" },
+  });
+});

--- a/supabase/migrations/20250811_phase10_auto_verify.sql
+++ b/supabase/migrations/20250811_phase10_auto_verify.sql
@@ -1,0 +1,13 @@
+-- Helpful indexes
+create index if not exists idx_payments_status_method on public.payments(status, payment_method);
+create index if not exists idx_payments_updated_at on public.payments(updated_at);
+
+-- Store app-wide verification tolerances in bot_settings (if not present)
+insert into public.bot_settings (content_key, content_value, content_type)
+select 'AMOUNT_TOLERANCE', '0.05', 'text'
+where not exists (select 1 from public.bot_settings where content_key='AMOUNT_TOLERANCE');
+
+insert into public.bot_settings (content_key, content_value, content_type)
+select 'WINDOW_SECONDS', '7200', 'text'  -- 2h receipt time window
+where not exists (select 1 from public.bot_settings where content_key='WINDOW_SECONDS');
+


### PR DESCRIPTION
## Summary
- add auto-verify migration with tolerance defaults
- edge function to OCR receipts and store structured data
- auto-review function to approve payments based on OCR and optional Binance hook
- stub Binance Pay webhook and deploy tasks
- document Phase 10 auto verification

## Testing
- `npx --yes supabase db push` *(fails: Cannot find project ref)*
- `npx --yes supabase functions deploy receipt-ocr` *(fails: Access token not provided)*
- `deno task test` *(fails: invalid peer certificate fetching npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_6899d032a51883229794ad8371a756e8