### PR TITLE
Add sync audit edge function with version endpoints

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -48,7 +48,8 @@
     "edge:deploy:security": "npx supabase functions deploy admin-bans && npx supabase functions deploy data-retention-cron && npx supabase functions deploy rotate-webhook-secret",
     "edge:deploy:ocr": "npx supabase functions deploy receipt-ocr",
     "edge:deploy:auto": "npx supabase functions deploy payments-auto-review",
-    "edge:deploy:binance": "npx supabase functions deploy binancepay-webhook"
+    "edge:deploy:binance": "npx supabase functions deploy binancepay-webhook",
+    "edge:deploy:sync": "npx supabase functions deploy sync-audit"
   }
 }
 // Schedules:

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -60,6 +60,23 @@ const TYPE = (p: string) =>
     : "application/octet-stream";
 
 serve((req) => {
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    if (url.pathname.endsWith("/version")) {
+      const ref = Deno.env.get("SUPABASE_URL")
+        ? new URL(Deno.env.get("SUPABASE_URL")!).hostname.split(".")[0]
+        : null;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          name: "miniapp",
+          project_ref: ref,
+          ts: new Date().toISOString(),
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }
+  }
   console.log(
     "miniapp hit",
     new Date().toISOString(),

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -1,0 +1,166 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const need = (k: string) =>
+  Deno.env.get(k) || (() => {
+    throw new Error(`Missing env ${k}`);
+  })();
+
+function projectRef(): string {
+  const u = need("SUPABASE_URL");
+  try {
+    return new URL(u).hostname.split(".")[0];
+  } catch {
+    return need("SUPABASE_PROJECT_ID");
+  }
+}
+function normUrl(u: string) {
+  return u.endsWith("/") ? u : (u + "/");
+}
+
+function genHex(n = 24) {
+  const b = new Uint8Array(n);
+  crypto.getRandomValues(b);
+  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+async function readDbSecret(supa: any): Promise<string | null> {
+  const { data } = await supa.from("bot_settings").select("setting_value").eq(
+    "setting_key",
+    "TELEGRAM_WEBHOOK_SECRET",
+  ).maybeSingle();
+  return (data?.setting_value as string) || null;
+}
+async function upsertDbSecret(supa: any, val: string) {
+  const { error } = await supa.from("bot_settings").upsert({
+    setting_key: "TELEGRAM_WEBHOOK_SECRET",
+    setting_value: val,
+  }, { onConflict: "setting_key" });
+  if (error) throw new Error("upsert bot_settings failed: " + error.message);
+}
+
+async function tg(token: string, method: string, body?: unknown) {
+  const r = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const j = await r.json().catch(() => ({}));
+  return { status: r.status, json: j };
+}
+
+serve(async (req) => {
+  if (req.method !== "POST" && req.method !== "GET") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  const ref = projectRef();
+  const expectedWebhook = `https://${ref}.functions.supabase.co/telegram-bot`;
+  const expectedMini = normUrl(
+    Deno.env.get("MINI_APP_URL") ||
+      `https://${ref}.functions.supabase.co/miniapp/`,
+  );
+
+  const supa = createClient(
+    need("SUPABASE_URL"),
+    need("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false } },
+  );
+  const token = need("TELEGRAM_BOT_TOKEN");
+
+  const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};
+  const fix = Boolean(body?.fix);
+
+  // 1) Telegram state
+  const webhookInfo = await tg(token, "getWebhookInfo");
+  const chatMenu = await tg(token, "getChatMenuButton");
+
+  const currentWebhook = webhookInfo.json?.result?.url || null;
+  const currentMenuUrl = chatMenu.json?.result?.menu_button?.web_app?.url ||
+    null;
+
+  // 2) Function reachability
+  async function fetchJSON(u: string) {
+    try {
+      const r = await fetch(u);
+      const j = await r.json();
+      return { ok: r.ok, j };
+    } catch {
+      return { ok: false, j: null };
+    }
+  }
+  const botVer = await fetchJSON(`${expectedWebhook}/version`);
+  const miniVer = await fetchJSON(`${expectedMini}version`);
+
+  // 3) Secret presence (ENV/DB)
+  const envSecret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || null;
+  let dbSecret = await readDbSecret(supa);
+
+  // 4) Compute mismatches
+  const mismatches: string[] = [];
+  if (currentWebhook !== expectedWebhook) mismatches.push("webhook_url");
+  if (currentMenuUrl !== expectedMini) mismatches.push("chat_menu_url");
+  if (!botVer.ok) mismatches.push("bot_unreachable");
+  if (!miniVer.ok) mismatches.push("mini_unreachable");
+  if (!envSecret && !dbSecret) mismatches.push("webhook_secret_missing");
+
+  // 5) Optional fixes
+  const actions: any[] = [];
+  if (fix) {
+    // Ensure we have a secret
+    if (!dbSecret && !envSecret) {
+      dbSecret = genHex(24);
+      await upsertDbSecret(supa, dbSecret);
+      actions.push({ set: "db_secret" });
+    }
+    const secret = dbSecret || envSecret!;
+
+    // Reapply webhook if needed
+    if (currentWebhook !== expectedWebhook) {
+      const set = await tg(token, "setWebhook", {
+        url: expectedWebhook,
+        secret_token: secret,
+        allowed_updates: ["message", "callback_query"],
+        drop_pending_updates: false,
+      });
+      actions.push({ setWebhook: set.json });
+    }
+
+    // Reset chat menu button if needed (add cache-busting v if requested)
+    const ver = body?.version || String(Date.now());
+    const targetMenu = body?.no_version
+      ? expectedMini
+      : `${expectedMini}?v=${ver}`;
+    if (currentMenuUrl !== targetMenu) {
+      const set = await tg(token, "setChatMenuButton", {
+        menu_button: {
+          type: "web_app",
+          text: "Open VIP Mini App",
+          web_app: { url: targetMenu },
+        },
+      });
+      actions.push({ setChatMenuButton: set.json, url: targetMenu });
+    }
+  }
+
+  const ok = mismatches.length === 0;
+
+  return new Response(
+    JSON.stringify(
+      {
+        ok,
+        expected: { webhook: expectedWebhook, miniapp: expectedMini },
+        actual: { webhook: currentWebhook, chat_menu: currentMenuUrl },
+        reachability: { bot: botVer.ok, mini: miniVer.ok },
+        secret: { env: !!envSecret, db: !!dbSecret },
+        mismatches,
+        actions,
+      },
+      null,
+      2,
+    ),
+    {
+      headers: { "content-type": "application/json" },
+      status: ok ? 200 : (fix ? 207 : 200),
+    },
+  );
+});

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -460,6 +460,25 @@ export async function serveWebhook(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    if (url.pathname.endsWith("/version")) {
+      const ref = Deno.env.get("SUPABASE_URL")
+        ? new URL(Deno.env.get("SUPABASE_URL")!).hostname.split(".")[0]
+        : null;
+      const mini = Deno.env.get("MINI_APP_URL") || null;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          name: "telegram-bot",
+          project_ref: ref,
+          mini_set: !!mini,
+          ts: new Date().toISOString(),
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }
+  }
   try {
     const { ok, missing } = requireEnvCheck(
       REQUIRED_ENV_KEYS as unknown as string[],


### PR DESCRIPTION
## Summary
- expose `/version` endpoints for telegram-bot and miniapp functions
- add `sync-audit` function to verify bot and mini app configuration and optionally self-heal
- include `edge:deploy:sync` task for deploying the new function

## Testing
- `deno task test` *(fails: Failed loading https://registry.npmjs.org/@eslint%2fjs for package "@eslint/js": invalid peer certificate)*
- `npx supabase functions deploy telegram-bot` *(fails: Access token not provided)*
- `npx supabase functions deploy miniapp` *(fails: Access token not provided)*
- `deno task -c deno.jsonc edge:deploy:sync` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6899d35d2ba4832296117f2a26b2b1d1