### PR TITLE
Send mini app button on Telegram /start

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -9,14 +9,22 @@ interface TelegramUpdate {
   message?: TelegramMessage;
 }
 
-async function sendMessage(chatId: number, text: string) {
+/**
+ * Minimal wrapper around Telegram's sendMessage API.
+ * Allows passing through optional payload fields like reply_markup.
+ */
+async function sendMessage(
+  chatId: number,
+  text: string,
+  extra?: Record<string, unknown>,
+) {
   const token = optionalEnv("TELEGRAM_BOT_TOKEN");
   if (!token) return;
   try {
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, text }),
+      body: JSON.stringify({ chat_id: chatId, text, ...extra }),
     });
   } catch (err) {
     console.error("sendMessage error", err);
@@ -60,7 +68,24 @@ export async function handler(req: Request): Promise<Response> {
   const command = text?.split(/\s+/)[0];
   if (command === "/start" && typeof chatId === "number") {
     try {
-      await sendMessage(chatId, "Bot activated. Replying to /start");
+      const miniUrl = optionalEnv("MINI_APP_URL");
+      const short = optionalEnv("MINI_APP_SHORT_NAME");
+      if (miniUrl || short) {
+        const botUsername = optionalEnv("TELEGRAM_BOT_USERNAME") || "";
+        const openUrl = miniUrl
+          ? (miniUrl.endsWith("/") ? miniUrl : miniUrl + "/")
+          : `https://t.me/${botUsername}?startapp=1`;
+        await sendMessage(chatId, "Open the VIP Mini App:", {
+          reply_markup: {
+            inline_keyboard: [[{
+              text: "Open VIP Mini App",
+              web_app: { url: openUrl },
+            }]],
+          },
+        });
+      } else {
+        await sendMessage(chatId, "Bot activated. Replying to /start");
+      }
     } catch (err) {
       console.error("error handling /start", err);
     }

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 
 Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("MINI_APP_URL", "https://example.com/app");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -19,6 +20,11 @@ Deno.test("webhook handles /start with params", async () => {
     assertEquals(res.status, 200);
     assertEquals(calls.length, 1);
     assertEquals(calls[0].url, "https://api.telegram.org/bottesttoken/sendMessage");
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(
+      payload.reply_markup.inline_keyboard[0][0].web_app.url,
+      "https://example.com/app/",
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- expose optional reply_markup in sendMessage helper
- reply to `/start` with mini app button when MINI_APP_URL or MINI_APP_SHORT_NAME set
- test updated for mini app link

## Testing
- `npm test` *(fails: Module not found "supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2")*
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check tests/telegram-webhook.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899dc38810083228151cc37a1eac9eb