### PR TITLE
fix: use relative asset paths for mini app

### DIFF
--- a/apps/miniapp-react/index.html
+++ b/apps/miniapp-react/index.html
@@ -8,6 +8,6 @@
   </head>
   <body class="bg-slate-50 dark:bg-slate-900">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/apps/miniapp-react/vite.config.ts
+++ b/apps/miniapp-react/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/supabase/functions/miniapp-health/index.ts
+++ b/supabase/functions/miniapp-health/index.ts
@@ -1,7 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { getEnv } from "../_shared/env.ts";
-// Supabase client (Deno ESM)
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 export async function getVipForTelegram(supa: any, tg: string): Promise<boolean | null> {
   const { data: users, error } = await supa
@@ -23,7 +21,7 @@ export async function getVipForTelegram(supa: any, tg: string): Promise<boolean 
   return isVip;
 }
 
-serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
@@ -38,18 +36,28 @@ serve(async (req) => {
 
   const url = getEnv("SUPABASE_URL");
   const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const { createClient } = await import(
+    "https://esm.sh/@supabase/supabase-js@2"
+  );
   const supa = createClient(url, srv, { auth: { persistSession: false } });
 
   let isVip: boolean | null = null;
   try {
     isVip = await getVipForTelegram(supa, tg);
   } catch (error) {
-    return new Response(JSON.stringify({ ok: false, error: (error as Error).message }), {
-      status: 500,
-    });
+    return new Response(
+      JSON.stringify({ ok: false, error: (error as Error).message }),
+      {
+        status: 500,
+      },
+    );
   }
 
   return new Response(JSON.stringify({ ok: true, vip: { is_vip: isVip } }), {
     headers: { "content-type": "application/json" },
   });
-});
+}
+
+if (import.meta.main) {
+  serve(handler);
+}

--- a/supabase/functions/miniapp/static/index.html
+++ b/supabase/functions/miniapp/static/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Dynamic Capital — VIP</title>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" crossorigin src="/assets/index-BHwarnKQ.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CNGF4XNV.css">
+    <script type="module" crossorigin src="assets/index-BHwarnKQ.js"></script>
+    <link rel="stylesheet" crossorigin href="assets/index-CNGF4XNV.css">
   </head>
   <body class="bg-slate-50 dark:bg-slate-900">
     <div id="root"></div>

--- a/supabase/functions/telegram-bot/vendor/import_map.json
+++ b/supabase/functions/telegram-bot/vendor/import_map.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "https://esm.sh/tesseract.js@5?dts": "./esm.sh/tesseract.js@5.1.1.js",
+    "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2",
     "https://esm.sh/": "./esm.sh/"
   },
   "scopes": {


### PR DESCRIPTION
## Summary
- ensure miniapp React build uses relative base path
- update miniapp static index to reference assets relatively
- load Supabase client lazily in Deno functions to allow tests to run without vendored modules
- keep import map from forcing missing local Supabase module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899dfda9da88322888945ab808f0160