### PR TITLE
feat: add shared http utils and handlers

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -49,7 +49,9 @@
     "edge:deploy:ocr": "npx supabase functions deploy receipt-ocr",
     "edge:deploy:auto": "npx supabase functions deploy payments-auto-review",
     "edge:deploy:binance": "npx supabase functions deploy binancepay-webhook",
-    "edge:deploy:sync": "npx supabase functions deploy sync-audit"
+    "edge:deploy:sync": "npx supabase functions deploy sync-audit",
+    "edge:deploy:bot": "npx supabase functions deploy telegram-bot",
+    "edge:deploy:mini": "npx supabase functions deploy miniapp"
   }
 }
 // Schedules:

--- a/docs/CONFIG_SECRETS.md
+++ b/docs/CONFIG_SECRETS.md
@@ -1,0 +1,6 @@
+# Config Secrets
+
+Supabase Edge secrets are the single source of truth for configuration. Never
+commit `.env` files or hard-coded secrets. When a webhook secret exists in the
+database (`bot_settings.TELEGRAM_WEBHOOK_SECRET`), it overrides the
+`TELEGRAM_WEBHOOK_SECRET` environment value.

--- a/supabase/functions/_shared/env.ts
+++ b/supabase/functions/_shared/env.ts
@@ -55,3 +55,11 @@ export function optionalEnv<K extends EnvKey>(key: K): string | null {
     (globalThis as unknown as { __TEST_ENV__?: TestEnv }).__TEST_ENV__;
   return Deno.env.get(key) ?? testEnv?.[key] ?? null;
 }
+
+export function need(k: string): string {
+  const v = Deno.env.get(k);
+  if (!v) throw new Error(`Missing env: ${k}`);
+  return v;
+}
+
+export const maybe = (k: string) => Deno.env.get(k) ?? null;

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -1,0 +1,22 @@
+export function json(
+  data: unknown,
+  status = 200,
+  extra: Record<string, string> = {},
+) {
+  const h = new Headers({
+    "content-type": "application/json; charset=utf-8",
+    ...extra,
+  });
+  return new Response(JSON.stringify(data), { status, headers: h });
+}
+export const ok = (data: unknown = {}) =>
+  json({ ok: true, ...((typeof data === "object" && data) || {}) }, 200);
+export const bad = (message = "Bad Request", hint?: unknown) =>
+  json({ ok: false, error: message, hint }, 400);
+export const unauth = (message = "Unauthorized") =>
+  json({ ok: false, error: message }, 401);
+export const nf = (message = "Not Found") =>
+  json({ ok: false, error: message }, 404);
+export const mna = () => json({ ok: false, error: "Method Not Allowed" }, 405);
+export const oops = (message: string, hint?: unknown) =>
+  json({ ok: false, error: message, hint }, 500);

--- a/supabase/functions/_shared/telegram_secret.ts
+++ b/supabase/functions/_shared/telegram_secret.ts
@@ -1,0 +1,32 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { maybe, need } from "./env.ts";
+import { oops, unauth } from "./http.ts";
+
+export async function readDbWebhookSecret(): Promise<string | null> {
+  try {
+    const supa = createClient(
+      need("SUPABASE_URL"),
+      need("SUPABASE_SERVICE_ROLE_KEY"),
+      { auth: { persistSession: false } },
+    );
+    const { data } = await supa.from("bot_settings")
+      .select("setting_value").eq("setting_key", "TELEGRAM_WEBHOOK_SECRET")
+      .limit(1).maybeSingle();
+    return (data?.setting_value as string) || null;
+  } catch {
+    return null;
+  }
+}
+export async function expectedSecret(): Promise<string | null> {
+  return (await readDbWebhookSecret()) || maybe("TELEGRAM_WEBHOOK_SECRET");
+}
+export async function validateTelegramHeader(
+  req: Request,
+): Promise<Response | null> {
+  const got = req.headers.get("X-Telegram-Bot-Api-Secret-Token") ||
+    req.headers.get("x-telegram-bot-api-secret-token") || "";
+  const exp = await expectedSecret();
+  if (!exp) return oops("Secret missing");
+  if (got !== exp) return unauth();
+  return null;
+}

--- a/supabase/functions/verify-initdata/index.ts
+++ b/supabase/functions/verify-initdata/index.ts
@@ -1,74 +1,49 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
+import { bad, ok } from "../_shared/http.ts";
 
 function toHex(buf: ArrayBuffer) {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 }
-async function hmacSHA256(key: CryptoKey, data: string) {
-  const enc = new TextEncoder();
-  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
-  return toHex(sig);
-}
-async function importHmacKeyFromToken(token: string) {
-  const enc = new TextEncoder();
-  const secretKey = await crypto.subtle.digest("SHA-256", enc.encode(token));
+async function importKey(token: string) {
+  const e = new TextEncoder();
+  const s = await crypto.subtle.digest("SHA-256", e.encode(token));
   return crypto.subtle.importKey(
     "raw",
-    secretKey,
+    s,
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],
   );
 }
 
-async function verifyDetailed(initData: string, windowSec: number) {
-  const token = getEnv("TELEGRAM_BOT_TOKEN");
-  const key = await importHmacKeyFromToken(token);
+export async function verifyFromRaw(
+  initData: string,
+  token: string,
+  windowSec = 900,
+) {
+  if (!initData) return false;
+  const key = await importKey(token);
   const params = new URLSearchParams(initData);
   const hash = params.get("hash") || "";
   params.delete("hash");
-  const pairs = Array.from(params.entries()).map(([k, v]) => `${k}=${v}`).sort();
-  const dataCheckString = pairs.join("\n");
-  const sig = await hmacSHA256(key, dataCheckString);
-  if (sig !== hash) return { ok: false, reason: "bad_signature" } as const;
+  const dcs = Array.from(params.entries()).map(([k, v]) => `${k}=${v}`).sort()
+    .join("\n");
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(dcs),
+  );
+  if (toHex(sig) !== hash) return false;
   const auth = Number(params.get("auth_date") || "0");
   const age = Math.floor(Date.now() / 1000) - auth;
-  if (windowSec > 0 && (isNaN(auth) || age > windowSec)) {
-    return { ok: false, reason: "stale" } as const;
-  }
-  return { ok: true } as const;
-}
-
-export async function verifyFromRaw(initData: string, windowSec = 900): Promise<boolean> {
-  const { ok } = await verifyDetailed(initData, windowSec);
-  return ok;
+  return !(windowSec > 0 && (isNaN(auth) || age > windowSec));
 }
 
 serve(async (req) => {
-  if (req.method !== "POST") {
-    return new Response("Method Not Allowed", { status: 405 });
-  }
-  let body: { initData?: string };
-  try {
-    body = await req.json();
-  } catch {
-    return new Response("Bad JSON", { status: 400 });
-  }
-  const raw = body.initData || "";
-  if (!raw) return new Response("Missing initData", { status: 400 });
-
-  const win = Number(Deno.env.get("WINDOW_SECONDS") ?? "900");
-  const ok = await verifyFromRaw(raw, win);
-  if (!ok) {
-    const res = await verifyDetailed(raw, win);
-    return new Response(
-      JSON.stringify({ ok: false, reason: res.reason }),
-      { status: 401 },
-    );
-  }
-
-  return new Response(JSON.stringify({ ok: true }), {
-    headers: { "content-type": "application/json" },
-  });
+  if (req.method !== "POST") return bad("Use POST");
+  const { initData } = await req.json().catch(() => ({}));
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+  const passed = await verifyFromRaw(initData || "", token);
+  return ok({ ok: passed });
 });


### PR DESCRIPTION
## Summary
- add shared JSON response helpers and env accessors
- implement Telegram secret validation and GET handlers
- expose miniapp and verify-initdata endpoints with standard responses

## Testing
- `deno fmt supabase/functions/_shared/http.ts supabase/functions/_shared/env.ts supabase/functions/_shared/telegram_secret.ts supabase/functions/telegram-bot/index.ts supabase/functions/miniapp/index.ts supabase/functions/verify-initdata/index.ts deno.jsonc docs/CONFIG_SECRETS.md`
- `deno task test` *(fails: invalid peer certificate)*
- `npx supabase login --token "$SUPABASE_ACCESS_TOKEN"` *(requires interactive login)*
- `npx supabase link --project-ref qeejuomcapbdlhnjqjcc` *(missing access token)*
- `npx supabase secrets list` *(missing access token)*
- `deno task -c deno.jsonc edge:deploy:bot` *(missing access token)*
- `deno task -c deno.jsonc edge:deploy:mini` *(missing access token)*
- `deno task -c deno.jsonc edge:deploy:verify` *(missing access token)*
- `deno task -c deno.jsonc edge:deploy:ops` *(missing access token)*
- `deno task -c deno.jsonc edge:deploy:sync` *(missing access token)*
- `curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-bot/version`
- `curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/version` *(401 missing authorization header)*
- `curl -s -X POST https://qeejuomcapbdlhnjqjcc.functions.supabase.co/sync-audit -H 'content-type: application/json' -d '{"fix":true,"version":"codex-fix-1"}'` *(401 missing authorization header)*
- `npx supabase functions logs --project-ref qeejuomcapbdlhnjqjcc --since 15m --slug telegram-bot` *(unknown flag: --project-ref)*
- `npx supabase functions logs --project-ref qeejuomcapbdlhnjqjcc --since 15m --slug miniapp` *(unknown flag: --project-ref)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef2c5c908322a469ea81c63db940