### PR TITLE
Add audit helper scripts for initData generation and report printing

### DIFF
--- a/scripts/make-initdata.ts
+++ b/scripts/make-initdata.ts
@@ -1,0 +1,18 @@
+const user = { id: 225513686, username: "prod_audit", first_name: "Audit" };
+function toHex(buf){ return [...new Uint8Array(buf)].map(b=>b.toString(16).padStart(2,"0")).join(""); }
+async function keyFromToken(t){
+  const enc = new TextEncoder();
+  const h = await crypto.subtle.digest("SHA-256", enc.encode(t));
+  return crypto.subtle.importKey("raw", h, { name:"HMAC", hash:"SHA-256" }, false, ["sign"]);
+}
+const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+if (!token) throw new Error("TELEGRAM_BOT_TOKEN missing");
+const params = new URLSearchParams({
+  user: encodeURIComponent(JSON.stringify(user)),
+  auth_date: String(Math.floor(Date.now()/1000)),
+  query_id: "AUDIT"
+});
+const dcs = Array.from(params.entries()).map(([k,v])=>`${k}=${v}`).sort().join("\n");
+const sig = await crypto.subtle.sign("HMAC", await keyFromToken(token), new TextEncoder().encode(dcs));
+params.set("hash", toHex(sig));
+console.log(params.toString());

--- a/scripts/print-report.ts
+++ b/scripts/print-report.ts
@@ -1,0 +1,72 @@
+const inputs = await new Response(await Deno.stdin.readable).text();
+const lines = inputs.trim().split("\n").filter(Boolean).map(s=>{try{return JSON.parse(s)}catch{return {raw:s}}});
+function pick(name){ return lines.find(x=>x.__name===name) || {}; }
+function as(name,obj){ return JSON.stringify({__name:name, ...obj}); }
+function yn(v){ return v ? "yes" : "no"; }
+const sec = pick("secrets");
+const ver = pick("versions");
+const sync = pick("sync");
+const ops = pick("ops");
+const admin = pick("admin_probe");
+const schedules = pick("schedules");
+const logsBot = pick("logs_bot");
+const logsMini = pick("logs_mini");
+
+function summarizeLogs(j){
+  if(!j || !j.lines) return "no logs";
+  const txt = j.lines.join("\n");
+  const c401 = (txt.match(/\b401\b/g)||[]).length;
+  const c403 = (txt.match(/\b403\b/g)||[]).length;
+  const c500 = (txt.match(/\b500\b/g)||[]).length;
+  const tops = txt.split("\n").filter(s=>/error|fatal|missing|Unauthorized|Secret|Internal/.test(s)).slice(0,3);
+  return `401=${c401} 403=${c403} 500=${c500}${tops.length?`\n  - ${tops.join("\n  - ")}`:""}`;
+}
+
+const okAll =
+  ver.bot_ok && ver.mini_ok &&
+  (sync.mismatches?.length===0) &&
+  ops.ok &&
+  !/500/.test(summarizeLogs(logsBot)) &&
+  !/500/.test(summarizeLogs(logsMini));
+
+console.log([
+"=== PROD READINESS REPORT ===",
+"",
+"SECRETS (presence only)",
+`- SUPABASE_URL: ${yn(sec.SUPABASE_URL)}`,
+`- SUPABASE_ANON_KEY: ${yn(sec.SUPABASE_ANON_KEY)}`,
+`- SUPABASE_SERVICE_ROLE_KEY: ${yn(sec.SUPABASE_SERVICE_ROLE_KEY)}`,
+`- TELEGRAM_BOT_TOKEN: ${yn(sec.TELEGRAM_BOT_TOKEN)}`,
+`- TELEGRAM_WEBHOOK_SECRET (env or DB): ${yn(sec.TELEGRAM_WEBHOOK_SECRET || sec.DB_WEBHOOK_SECRET)}`,
+`- MINI_APP_URL: ${yn(sec.MINI_APP_URL)}`,
+"",
+"ENDPOINTS",
+`- /telegram-bot/version: ${ver.bot_status} ok=${yn(ver.bot_ok)}`,
+`- /miniapp/version: ${ver.mini_status} ok=${yn(ver.mini_ok)}`,
+"",
+"SYNC",
+`- expected webhook: ${sync.expected_webhook || "-"}`,
+`- actual webhook:   ${sync.actual_webhook || "-"}`,
+`- expected miniapp: ${sync.expected_mini || "-"}`,
+`- chat menu url:    ${sync.actual_menu || "-"}`,
+`- mismatches: ${sync.mismatches?.join(", ") || "none"}`,
+`- self-heal actions: ${sync.actions?.length ? JSON.stringify(sync.actions) : "none"}`,
+"",
+"OPS HEALTH",
+`- ops-health ok: ${yn(ops.ok)}  db:${yn(ops.db)} secrets_ok:${yn(ops.secrets_ok)}`,
+"",
+"ADMIN PROBE",
+`- admin-review-payment auth: ${admin.status || "-"}`,
+"",
+"SCHEDULES",
+`- found: ${(schedules.names||[]).join(", ") || "-"}`,
+"",
+"LOGS (15m)",
+"- telegram-bot:",
+summarizeLogs(logsBot),
+"- miniapp:",
+summarizeLogs(logsMini),
+"",
+`OVERALL: ${okAll ? "PASS ✅" : "ATTENTION ⚠️"}`,
+okAll ? "" : "Next steps: resolve mismatches via sync-audit fix; ensure ops-health ok; address 500s seen in logs; verify admin header; redeploy failing functions."
+].join("\n"));


### PR DESCRIPTION
## Summary
- add script to generate Telegram WebApp initData using TELEGRAM_BOT_TOKEN
- add script to assemble PROD READINESS REPORT from JSON lines

## Testing
- `npm test` *(fails: verify-initdata: accepts valid signature)*

------
https://chatgpt.com/codex/tasks/task_e_6899f8f3a58c8322a90ef99a60ba0bb4