### PR TITLE
fix: apply high-priority edge fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "test": "deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check",
+    "test": "deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,esm.sh -A --no-check",
     "preview": "vite preview",
     "setup:supabase": "bash scripts/setup-supabase-cli.sh"
   },

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+import { ok, bad, nf, mna, unauth } from "../_shared/http.ts";
 
 type Body = { initData: string; payment_id: string; decision: "approve"|"reject"; months?: number; message?: string };
 
@@ -12,11 +13,11 @@ async function tgSend(token: string, chatId: string, text: string) {
 }
 
 serve(async (req) => {
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
-  let body: Body; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
+  if (req.method !== "POST") return mna();
+  let body: Body; try { body = await req.json(); } catch { return bad("Bad JSON"); }
 
   const u = await verifyInitDataAndGetUser(body.initData || "");
-  if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
+  if (!u || !isAdmin(u.id)) return unauth();
 
   const url = Deno.env.get("SUPABASE_URL")!;
   const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -25,9 +26,9 @@ serve(async (req) => {
 
   // Load payment + user + plan
   const { data: p } = await supa.from("payments").select("id,status,user_id,plan_id,amount,currency,created_at").eq("id", body.payment_id).maybeSingle();
-  if (!p) return new Response("Payment not found", { status: 404 });
+  if (!p) return nf("Payment not found");
   const { data: user } = await supa.from("bot_users").select("id,telegram_id,subscription_expires_at,is_vip").eq("id", p.user_id).maybeSingle();
-  if (!user) return new Response("User not found", { status: 404 });
+  if (!user) return nf("User not found");
 
   if (body.decision === "reject") {
     await supa.from("payments").update({ status: "rejected" }).eq("id", p.id);
@@ -40,7 +41,7 @@ serve(async (req) => {
       affected_record_id: p.id,
       new_values: { status: "rejected" }
     });
-    return new Response(JSON.stringify({ ok:true, status:"rejected" }), { headers: { "content-type":"application/json" }});
+    return ok({ status: "rejected" });
   }
 
   // approve
@@ -71,5 +72,5 @@ serve(async (req) => {
     new_values: { is_vip: true, subscription_expires_at: expiresAt }
   });
 
-  return new Response(JSON.stringify({ ok:true, status:"completed", subscription_expires_at: expiresAt }), { headers: { "content-type":"application/json" }});
+  return ok({ status: "completed", subscription_expires_at: expiresAt });
 });

--- a/supabase/functions/broadcast-cron/index.ts
+++ b/supabase/functions/broadcast-cron/index.ts
@@ -2,7 +2,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { requireEnv } from "../_shared/env.ts";
 import { functionUrl } from "../_shared/edge.ts";
-import { ok } from "../_shared/http.ts";
+import { ok, oops } from "../_shared/http.ts";
 
 serve(async (req) => {
   const url = new URL(req.url);
@@ -10,27 +10,32 @@ serve(async (req) => {
     return ok({ name: "broadcast-cron", ts: new Date().toISOString() });
   }
   if (req.method === "HEAD") return new Response(null, { status: 200 });
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-    ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
-  );
-  const headers = {
-    apikey: SUPABASE_SERVICE_ROLE_KEY,
-    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-  };
-  const r = await fetch(
-    `${SUPABASE_URL}/rest/v1/broadcast_messages?delivery_status=eq.scheduled&scheduled_at=lte.${new Date().toISOString()}&select=id`,
-    { headers },
-  );
-  const rows = await r.json();
-  const url = functionUrl("broadcast-dispatch");
-  for (const row of rows || []) {
-    if (!url) break;
-    await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ id: row.id }),
-    });
+  try {
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
+      ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
+    );
+    const headers = {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    };
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/broadcast_messages?delivery_status=eq.scheduled&scheduled_at=lte.${new Date().toISOString()}&select=id`,
+      { headers },
+    );
+    const rows = await r.json();
+    const url = functionUrl("broadcast-dispatch");
+    for (const row of rows || []) {
+      if (!url) break;
+      await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: row.id }),
+      });
+    }
+    return ok();
+  } catch (err) {
+    console.error("broadcast-cron error", err);
+    return oops("Failed to dispatch broadcasts", String(err));
   }
-  return new Response(JSON.stringify({ ok: true }), { headers: { "content-type": "application/json" } });
 });
 // <<< DC BLOCK: broadcast-cron-core (end)

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1,6 +1,7 @@
 // Enhanced admin handlers for comprehensive table management
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { optionalEnv, requireEnv } from "../_shared/env.ts";
+import { expectedSecret } from "../_shared/telegram_secret.ts";
 
 const {
   SUPABASE_URL,
@@ -1542,14 +1543,14 @@ export function handleVersion() {
   return { version: optionalEnv("BOT_VERSION") || "unknown" };
 }
 
-export function handleEnvStatus() {
+export async function handleEnvStatus() {
   const base = requireEnv([
     "SUPABASE_URL",
     "SUPABASE_SERVICE_ROLE_KEY",
     "TELEGRAM_BOT_TOKEN",
-    "TELEGRAM_WEBHOOK_SECRET",
   ]);
-  return base;
+  const secret = await expectedSecret();
+  return { ...base, TELEGRAM_WEBHOOK_SECRET: secret ? true : false };
 }
 
 export async function handleReviewList() {

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -369,12 +369,11 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
           JSON.stringify((await loadAdminHandlers()).handleVersion()),
         );
         break;
-      case "/env":
-        await notifyUser(
-          chatId,
-          JSON.stringify((await loadAdminHandlers()).handleEnvStatus()),
-        );
+      case "/env": {
+        const envStatus = await (await loadAdminHandlers()).handleEnvStatus();
+        await notifyUser(chatId, JSON.stringify(envStatus));
         break;
+      }
       case "/reviewlist": {
         const { handleReviewList } = await loadAdminHandlers();
         const list = await handleReviewList();
@@ -457,7 +456,7 @@ export async function serveWebhook(req: Request): Promise<Response> {
     );
     if (!envOk) {
       console.error("Missing env vars", missing);
-      return ok();
+      return oops("Missing env vars", missing);
     }
 
     const body = await extractTelegramUpdate(req);

--- a/supabase/functions/telegram-getwebhook/index.ts
+++ b/supabase/functions/telegram-getwebhook/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { optionalEnv } from "../_shared/env.ts";
+import { expectedSecret } from "../_shared/telegram_secret.ts";
+import { ok, oops, mna } from "../_shared/http.ts";
 
 const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
-const SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
 const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const FN = "telegram-webhook";
 const expected = BASE ? `${BASE}/functions/v1/${FN}` : null;
@@ -11,28 +12,24 @@ function red(s: string, keep = 4) {
   return s ? s.slice(0, keep) + "...redacted" : "";
 }
 
-serve(async () => {
+serve(async (req) => {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname.endsWith("/version")) {
+    return ok({ name: "telegram-getwebhook", ts: new Date().toISOString() });
+  }
+  if (req.method === "HEAD") return new Response(null, { status: 200 });
+  if (req.method !== "GET") return mna();
+
+  const SECRET = await expectedSecret();
   if (!BOT) {
-    return new Response(
-      JSON.stringify({ ok: false, error: "BOT_TOKEN missing" }),
-      { headers: { "content-type": "application/json" }, status: 500 },
-    );
+    return oops("BOT_TOKEN missing");
   }
   const info = await fetch(`https://api.telegram.org/bot${BOT}/getWebhookInfo`)
     .then((r) => r.json()).catch((e) => ({ ok: false, error: String(e) }));
-  return new Response(
-    JSON.stringify({
-      ok: true,
-      expected_url: expected,
-      has_secret: !!SECRET,
-      token_preview: red(BOT),
-      webhook_info: info,
-    }),
-    {
-      headers: {
-        "content-type": "application/json",
-        "cache-control": "no-store",
-      },
-    },
-  );
+  return ok({
+    expected_url: expected,
+    has_secret: !!SECRET,
+    token_preview: red(BOT),
+    webhook_info: info,
+  });
 });

--- a/supabase/functions/telegram-setwebhook/index.ts
+++ b/supabase/functions/telegram-setwebhook/index.ts
@@ -1,33 +1,30 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { optionalEnv } from "../_shared/env.ts";
+import { expectedSecret } from "../_shared/telegram_secret.ts";
+import { ok, oops, mna } from "../_shared/http.ts";
 
 const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
-const SECRET = optionalEnv("TELEGRAM_WEBHOOK_SECRET") || "";
 const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const FN = "telegram-webhook";
 const url = BASE ? `${BASE}/functions/v1/${FN}` : "";
 
 serve(async (req) => {
-  if (!BOT || !url) {
-    return new Response(
-      JSON.stringify({ ok: false, error: "Missing BOT or BASE URL" }),
-      { status: 500, headers: { "content-type": "application/json" } },
-    );
-  }
   const u = new URL(req.url);
+  if (req.method === "GET" && u.pathname.endsWith("/version")) {
+    return ok({ name: "telegram-setwebhook", ts: new Date().toISOString() });
+  }
+  if (req.method === "HEAD") return new Response(null, { status: 200 });
+  if (req.method !== "GET") return mna();
+
+  const SECRET = await expectedSecret();
+  if (!BOT || !url) {
+    return oops("Missing BOT or BASE URL");
+  }
   const drop = u.searchParams.get("drop") === "1"; // optional: delete webhook first
   const dry = u.searchParams.get("dry") === "1"; // optional: dry-run
 
   if (dry) {
-    return new Response(
-      JSON.stringify({
-        ok: true,
-        dry: true,
-        target: url,
-        uses_secret: !!SECRET,
-      }),
-      { headers: { "content-type": "application/json" } },
-    );
+    return ok({ dry: true, target: url, uses_secret: !!SECRET });
   }
 
   if (drop) {
@@ -45,19 +42,11 @@ serve(async (req) => {
     body: form,
   });
   const json = await res.json().catch(() => null);
-  return new Response(
-    JSON.stringify({
-      ok: res.ok,
-      status: res.status,
-      result: json,
-      target: url,
-      used_secret: !!SECRET,
-    }),
-    {
-      headers: {
-        "content-type": "application/json",
-        "cache-control": "no-store",
-      },
-    },
-  );
+  return ok({
+    telegram_ok: res.ok,
+    status: res.status,
+    result: json,
+    target: url,
+    used_secret: !!SECRET,
+  });
 });

--- a/supabase/functions/telegram-start-sim/index.ts
+++ b/supabase/functions/telegram-start-sim/index.ts
@@ -1,43 +1,37 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { optionalEnv } from "../_shared/env.ts";
+import { expectedSecret } from "../_shared/telegram_secret.ts";
+import { ok, bad, oops, mna } from "../_shared/http.ts";
 
 serve(async (req) => {
-  const headers = {
-    "Content-Type": "application/json",
-    "Cache-Control": "no-store",
-  };
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname.endsWith("/version")) {
+    return ok({ name: "telegram-start-sim", ts: new Date().toISOString() });
+  }
+  if (req.method === "HEAD") return new Response(null, { status: 200 });
 
   try {
     let chatId: number | null = null;
 
     if (req.method === "GET") {
-      const url = new URL(req.url);
       const id = url.searchParams.get("chat_id");
       if (id) chatId = Number(id);
     } else if (req.method === "POST") {
-      try {
-        const body = await req.json();
-        if (body && body.chat_id !== undefined) {
-          chatId = Number(body.chat_id);
-        }
-      } catch {
-        // ignore JSON parse errors
+      const body = await req.json().catch(() => ({}));
+      if (body && body.chat_id !== undefined) {
+        chatId = Number(body.chat_id);
       }
+    } else {
+      return mna();
     }
 
     if (!chatId) {
-      return new Response(
-        JSON.stringify({ ok: false, error: "chat_id is required" }),
-        { status: 400, headers },
-      );
+      return bad("chat_id is required");
     }
 
     const base = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
     if (!base) {
-      return new Response(
-        JSON.stringify({ ok: false, error: "SUPABASE_URL not set" }),
-        { status: 500, headers },
-      );
+      return oops("SUPABASE_URL not set");
     }
 
     const webhookUrl = `${base}/functions/v1/telegram-webhook`;
@@ -56,7 +50,7 @@ serve(async (req) => {
       "Content-Type": "application/json",
     };
 
-    const secret = optionalEnv("TELEGRAM_WEBHOOK_SECRET");
+    const secret = await expectedSecret();
     if (secret) {
       fetchHeaders["x-telegram-bot-api-secret-token"] = secret;
     }
@@ -70,19 +64,13 @@ serve(async (req) => {
 
     const text = await resp.text();
 
-    return new Response(
-      JSON.stringify({
-        ok: resp.ok,
-        status: resp.status,
-        webhook_url: webhookUrl,
-        preview: text.slice(0, 300),
-      }),
-      { headers },
-    );
+    return ok({
+      telegram_ok: resp.ok,
+      status: resp.status,
+      webhook_url: webhookUrl,
+      preview: text.slice(0, 300),
+    });
   } catch (err) {
-    return new Response(
-      JSON.stringify({ ok: false, error: String(err) }),
-      { status: 500, headers },
-    );
+    return oops("start-sim failed", String(err));
   }
 });

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -1,5 +1,5 @@
 import { optionalEnv } from "../_shared/env.ts";
-import { ok, mna, oops } from "../_shared/http.ts";
+import { ok, mna, oops, bad } from "../_shared/http.ts";
 import { validateTelegramHeader } from "../_shared/telegram_secret.ts";
 
 interface TelegramMessage {
@@ -57,7 +57,7 @@ export async function handler(req: Request): Promise<Response> {
       update = await req.json() as TelegramUpdate;
     } catch (err) {
       console.error("failed to parse update", err);
-      return ok({ ok: true });
+      return bad("Invalid JSON");
     }
 
     const text = update?.message?.text?.trim();


### PR DESCRIPTION
## Summary
- allow Deno tests to resolve esm.sh modules by ignoring its TLS certificate
- return structured JSON with shared helpers and add `/version` + `HEAD` handlers across Telegram admin utilities

## Testing
- `npm test` *(fails: Module not found "file:///workspace/Dynamic-Chatty-Bot/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/auth-js@2.71.1/denonext/auth-js.mjs")*

------
https://chatgpt.com/codex/tasks/task_e_689a97943190832280a6b71806927540