### PR TITLE
refactor: simplify telegram secret fetch

### DIFF
--- a/supabase/functions/verify-initdata/index.ts
+++ b/supabase/functions/verify-initdata/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { bad, ok } from "../_shared/http.ts";
+import { getEnv } from "../_shared/env.ts";
 
 function toHex(buf: ArrayBuffer) {
   return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0"))
@@ -19,8 +20,8 @@ async function importKey(token: string) {
 
 export async function verifyFromRaw(
   initData: string,
-  token: string,
   windowSec = 900,
+  token = getEnv("TELEGRAM_BOT_TOKEN"),
 ) {
   if (!initData) return false;
   const key = await importKey(token);
@@ -43,7 +44,6 @@ export async function verifyFromRaw(
 serve(async (req) => {
   if (req.method !== "POST") return bad("Use POST");
   const { initData } = await req.json().catch(() => ({}));
-  const token = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
-  const passed = await verifyFromRaw(initData || "", token);
+  const passed = await verifyFromRaw(initData || "");
   return ok({ ok: passed });
 });


### PR DESCRIPTION
## Summary
- avoid external supabase client dependency for telegram webhook secret
- add optional env override for webhook keeper
- read token from env in verify-initdata and relax secret header check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ab714d8508322a599a0293f864acc