### PR TITLE
fix: include short name in mini app link

### DIFF
--- a/functions/_tests/start-command.test.ts
+++ b/functions/_tests/start-command.test.ts
@@ -21,7 +21,7 @@ setTestEnv({
   SUPABASE_URL: "http://local",
   SUPABASE_ANON_KEY: "test-anon",
   SUPABASE_SERVICE_ROLE_KEY: "test-svc",
-  TELEGRAM_BOT_TOKEN: "",
+  TELEGRAM_BOT_TOKEN: "test-token",
   TELEGRAM_WEBHOOK_SECRET: "test-secret",
 });
 

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -133,7 +133,7 @@ async function sendMiniAppLink(chatId: number): Promise<void> {
   if (miniUrl) {
     openUrl = miniUrl.endsWith("/") ? miniUrl : miniUrl + "/";
   } else if (short && botUsername) {
-    openUrl = `https://t.me/${botUsername}?startapp=1`;
+    openUrl = `https://t.me/${botUsername}/${short}`;
   }
   if (!openUrl || !isValidHttpsUrl(openUrl)) {
     await sendMessage(

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1,9 +1,9 @@
 import { optionalEnv } from "../_shared/env.ts";
 import { requireEnv as requireEnvCheck } from "./helpers/require-env.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { alertAdmins } from "../_shared/alerts.ts";
 import { json, mna, ok, oops } from "../_shared/http.ts";
 import { validateTelegramHeader } from "../_shared/telegram_secret.ts";
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 interface TelegramMessage {
   chat: { id: number };
@@ -48,8 +48,6 @@ const _FAQ_ENABLED = optionalEnv("FAQ_ENABLED") === "true";
 const WINDOW_SECONDS = Number(optionalEnv("WINDOW_SECONDS") ?? "180");
 const AMOUNT_TOLERANCE = Number(optionalEnv("AMOUNT_TOLERANCE") ?? "0.02");
 const REQUIRE_PAY_CODE = optionalEnv("REQUIRE_PAY_CODE") === "true";
-
-type SupabaseClient = any;
 let supabaseAdmin: SupabaseClient | null = null;
 async function getSupabase(): Promise<SupabaseClient | null> {
   if (supabaseAdmin) return supabaseAdmin;

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -83,7 +83,7 @@ export async function handler(req: Request): Promise<Response> {
         if (miniUrl) {
           openUrl = miniUrl.endsWith("/") ? miniUrl : miniUrl + "/";
         } else if (short && botUsername) {
-          openUrl = `https://t.me/${botUsername}?startapp=1`;
+          openUrl = `https://t.me/${botUsername}/${short}`;
         }
         if (!openUrl || !isValidHttpsUrl(openUrl)) {
           await sendMessage(

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -30,6 +30,37 @@ Deno.test("webhook handles /start with params", async () => {
   }
 });
 
+Deno.test("webhook uses short name when URL absent", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.delete("MINI_APP_URL");
+  Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(calls.length, 1);
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(
+      payload.reply_markup.inline_keyboard[0][0].web_app.url,
+      "https://t.me/mybot/shorty",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("webhook falls back for invalid mini app url", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set("MINI_APP_URL", "http://invalid-url");


### PR DESCRIPTION
## Summary
- ensure mini-app link uses Telegram short name when URL is absent
- add regression test for short-name mini-app links

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_689ace82bd98832292534950d9bfa83e