### PR TITLE
docs: reference edge mini app URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,5 @@ OPENAI_ENABLED=
 FAQ_ENABLED=
 WINDOW_SECONDS=
 AMOUNT_TOLERANCE=
-# e.g. https://mini.dynamic.capital or https://dynamic-capital-mini.vercel.app
+# e.g. https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
 MINI_APP_URL=

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,8 +1,6 @@
 # Configuration
 
-The project relies on a shared set of environment keys. Set them in your local
-`.env`, Supabase function secrets, and GitHub Actions secrets as indicated
-below.
+The project relies on a shared set of environment keys. Set them in your local `.env`, Supabase function secrets, and GitHub Actions secrets as indicated below.
 
 | Key                       | Codex project settings (dev) | Supabase function secrets (prod) | GitHub Actions secrets (CI) |
 | ------------------------- | ---------------------------- | -------------------------------- | --------------------------- |
@@ -24,6 +22,4 @@ below.
 
 `✅` indicates where each key should be set.
 
-`MINI_APP_URL` should point to the deployed Telegram Mini App (for example,
-`https://mini.dynamic.capital/`). If set, the bot shows a Mini App button and
-will automatically append a trailing slash if missing to avoid redirect issues.
+`MINI_APP_URL` should point to the deployed Telegram Mini App (for example, `https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/`). If set, the bot shows a Mini App button and will automatically append a trailing slash if missing to avoid redirect issues.

--- a/docs/MINI_APP_URL_SETUP.md
+++ b/docs/MINI_APP_URL_SETUP.md
@@ -13,7 +13,7 @@ wasn’t redeployed after setting them).
    npx supabase login
    npx supabase link --project-ref <PROJECT_REF>
    # Provide either a full URL or a short name
-   npx supabase secrets set MINI_APP_URL=https://mini.dynamic.capital/
+   npx supabase secrets set MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
    # or
    # npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
    npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
@@ -31,7 +31,7 @@ wasn’t redeployed after setting them).
    ```bash
    export TELEGRAM_BOT_TOKEN=<token>
    # Either MINI_APP_URL or MINI_APP_SHORT_NAME
-   export MINI_APP_URL=https://mini.dynamic.capital/
+   export MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
    # export MINI_APP_SHORT_NAME=<short_name>
    deno run -A scripts/set-chat-menu-button.ts
    ```


### PR DESCRIPTION
## Summary
- document Supabase Edge Functions mini app URL in env example
- update setup instructions to use Edge Functions URL
- clarify config guidance with Supabase Edge URL example

## Testing
- `~/.deno/bin/deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org -A --no-check`


------
https://chatgpt.com/codex/tasks/task_e_689ade2b244c83229f06854fec00d96c