### PR TITLE
Allow tg-verify-init without JWT

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -53,3 +53,6 @@ verify_jwt = false
 
 [functions.telegram-start-sim]
 verify_jwt = false
+
+[functions.tg-verify-init]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- Disable JWT requirement for the `tg-verify-init` edge function so it can be called without a Supabase auth header

## Testing
- `npm test`
- `npm run lint` *(fails: 52 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689ae2a8eaac8322beb6e006323ab70f