### PR TITLE
Fix ESLint errors across project

### DIFF
--- a/apps/mini/src/lib/edge.ts
+++ b/apps/mini/src/lib/edge.ts
@@ -1,9 +1,14 @@
+interface ViteMeta {
+  env?: Record<string, string | undefined>;
+}
+
 export function functionUrl(name: string): string | null {
+  const meta = import.meta as ImportMeta & ViteMeta;
   const ref =
-    (import.meta as any).env?.VITE_SUPABASE_PROJECT_ID ||
+    meta.env?.VITE_SUPABASE_PROJECT_ID ||
     (() => {
       try {
-        const url = (import.meta as any).env?.VITE_SUPABASE_URL;
+        const url = meta.env?.VITE_SUPABASE_URL;
         return url ? new URL(url).hostname.split('.')[0] : null;
       } catch {
         return null;

--- a/apps/miniapp-react/src/lib/edge.ts
+++ b/apps/miniapp-react/src/lib/edge.ts
@@ -1,8 +1,20 @@
+interface ViteMeta {
+  env?: Record<string, string | undefined>;
+}
+
+const meta = import.meta as ImportMeta & ViteMeta;
+
 export function getProjectRef(): string | null {
-  const pr = (import.meta as any).env?.VITE_SUPABASE_PROJECT_ID as string | undefined;
+  const pr = meta.env?.VITE_SUPABASE_PROJECT_ID;
   if (pr) return pr;
-  const sb = (import.meta as any).env?.VITE_SUPABASE_URL as string | undefined;
-  if (sb) { try { return new URL(sb).hostname.split('.')[0]; } catch {} }
+  const sb = meta.env?.VITE_SUPABASE_URL;
+  if (sb) {
+    try {
+      return new URL(sb).hostname.split('.')[0];
+    } catch {
+      // ignore parsing errors
+    }
+  }
   return new URLSearchParams(location.search).get('pr');
 }
 export function functionUrl(name: string): string | null {
@@ -10,8 +22,8 @@ export function functionUrl(name: string): string | null {
   return ref ? `https://${ref}.functions.supabase.co/${name}` : null;
 }
 export function supabaseUrl(): string | null {
-  return (import.meta as any).env?.VITE_SUPABASE_URL || new URLSearchParams(location.search).get('sb');
+  return meta.env?.VITE_SUPABASE_URL || new URLSearchParams(location.search).get('sb');
 }
 export function anonKey(): string | null {
-  return (import.meta as any).env?.VITE_SUPABASE_ANON_KEY || new URLSearchParams(location.search).get('anon');
+  return meta.env?.VITE_SUPABASE_ANON_KEY || new URLSearchParams(location.search).get('anon');
 }

--- a/apps/miniapp-react/src/routes/Diag.tsx
+++ b/apps/miniapp-react/src/routes/Diag.tsx
@@ -4,8 +4,7 @@ import { functionUrl } from "@/lib/edge";
 
 export default function Diag() {
   const { initData, user } = useTelegram();
-  // deno-lint-ignore no-explicit-any
-  const [out, setOut] = useState<any>(null);
+  const [out, setOut] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(false);
 
   async function run() {

--- a/apps/miniapp-react/src/routes/admin/Logs.tsx
+++ b/apps/miniapp-react/src/routes/admin/Logs.tsx
@@ -4,7 +4,7 @@ import { adminFetchLogs } from '@/services/api';
 
 export default function Logs() {
   const { initData } = useTelegram();
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<Record<string, unknown>[]>([]);
   useEffect(() => { (async () => {
     const j = await adminFetchLogs(initData || "", 50, 0);
     setItems(j.items || []);

--- a/apps/miniapp-react/src/routes/admin/Payments.tsx
+++ b/apps/miniapp-react/src/routes/admin/Payments.tsx
@@ -4,7 +4,7 @@ import { adminListPending, adminActOnPayment } from '@/services/api';
 
 export default function Payments() {
   const { initData, haptic } = useTelegram();
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<Record<string, unknown>[]>([]);
   const [loading, setLoading] = useState(true);
 
   async function load() {

--- a/apps/miniapp-react/src/shared/useTelegram.ts
+++ b/apps/miniapp-react/src/shared/useTelegram.ts
@@ -1,18 +1,34 @@
 import { useEffect, useMemo } from 'react';
+
+interface TelegramWebApp {
+  ready?: () => void;
+  expand?: () => void;
+  colorScheme?: string;
+  initData?: string;
+  initDataUnsafe?: Record<string, unknown>;
+  HapticFeedback?: { impactOccurred?: (strength: string) => void };
+}
+
 export function useTelegram() {
-  const tg = (window as any).Telegram?.WebApp;
+  const tg = (window as { Telegram?: { WebApp?: TelegramWebApp } }).Telegram?.WebApp;
   useEffect(() => {
     try {
       tg?.ready?.();
       tg?.expand?.();
       const theme = tg?.colorScheme || 'light';
       document.documentElement.classList.toggle('dark', theme === 'dark');
-    } catch {}
+    } catch {
+      // ignore errors from Telegram initialization
+    }
   }, []);
-  return useMemo(() => ({
-    initData: tg?.initData || '',
-    initDataUnsafe: tg?.initDataUnsafe || {},
-    user: tg?.initDataUnsafe?.user || null,
-    haptic: (strength: 'light'|'medium'|'heavy' = 'light') => tg?.HapticFeedback?.impactOccurred?.(strength)
-  }), [tg]);
+  return useMemo(
+    () => ({
+      initData: tg?.initData || '',
+      initDataUnsafe: tg?.initDataUnsafe || {},
+      user: (tg?.initDataUnsafe as { user?: unknown } | undefined)?.user || null,
+      haptic: (strength: 'light' | 'medium' | 'heavy' = 'light') =>
+        tg?.HapticFeedback?.impactOccurred?.(strength),
+    }),
+    [tg],
+  );
 }

--- a/functions/_tests/miniapp-health.test.ts
+++ b/functions/_tests/miniapp-health.test.ts
@@ -6,7 +6,7 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
-let mod: any = null;
+let mod: Record<string, unknown> | null = null;
 try {
   mod = await import("../../supabase/functions/miniapp-health/index.ts");
 } catch {

--- a/functions/_tests/start-command.test.ts
+++ b/functions/_tests/start-command.test.ts
@@ -32,7 +32,7 @@ const candidates = [
   "../../edge/telegram-bot/index.ts",
 ];
 
-let mod: any = null;
+let mod: Record<string, unknown> | null = null;
 let used: string | null = null;
 for (const p of candidates) {
   try {
@@ -85,8 +85,12 @@ Deno.test("handler responds to /start offline", async () => {
       // Try with injected deps (mock fetch + supabase) if supported
       const mockFetch: typeof fetch = async () =>
         new Response("{}", { status: 200 });
-      const mockSupabase = () =>
-        ({ from: () => ({ insert: () => ({ error: null }) }) }) as any;
+      type MockSupabase = {
+        from: () => { insert: () => { error: null } };
+      };
+      const mockSupabase = (): MockSupabase => ({
+        from: () => ({ insert: () => ({ error: null }) }),
+      });
       res = await mod.default(req, {
         fetcher: mockFetch,
         supabaseFactory: mockSupabase,

--- a/scripts/audit-edge-hosts.ts
+++ b/scripts/audit-edge-hosts.ts
@@ -19,7 +19,7 @@ async function scan(dir: string) {
     const buf = await Deno.readFile(p).catch(() => null);
     if (!buf) continue;
     const txt = decoder.decode(buf);
-    const re = /https:\/\/([a-z0-9\-]+)\.functions\.supabase\.co\/[A-Za-z0-9_\-\/]+/g;
+    const re = /https:\/\/([a-z0-9-]+)\.functions\.supabase\.co\/[A-Za-z0-9_/-]+/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(txt))) {
       const url = m[0];

--- a/scripts/guard-service-role.ts
+++ b/scripts/guard-service-role.ts
@@ -38,7 +38,7 @@ async function scan(dir: string) {
 
     // Hard rule: no literal-looking service-role key (very naive pattern)
     // Matches long base64-like strings; adjust if you get false positives.
-    const highEntropy = /[A-Za-z0-9_\-]{40,}/g;
+    const highEntropy = /[A-Za-z0-9_-]{40,}/g;
     if (txt.match(highEntropy) && txt.includes("supabase")) {
       console.error(`Possible secret material in ${p}. Remove and rotate if real.`);
       bad = true;

--- a/scripts/ping-webhook.ts
+++ b/scripts/ping-webhook.ts
@@ -21,7 +21,7 @@ if (!secret) {
 const explicitUrl = Deno.env.get("TELEGRAM_WEBHOOK_URL");
 const proj = Deno.env.get("SUPABASE_PROJECT_ID");
 
-let baseUrl =
+const baseUrl =
   explicitUrl ?? (proj ? `https://${proj}.functions.supabase.co/telegram-bot` : null);
 
 if (!baseUrl) {

--- a/supabase/functions/_shared/telegram_secret.ts
+++ b/supabase/functions/_shared/telegram_secret.ts
@@ -1,7 +1,19 @@
 import { maybe, need } from "./env.ts";
 import { unauth } from "./http.ts";
 
-export async function readDbWebhookSecret(supa?: any): Promise<string | null> {
+interface SupabaseLike {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (key: string, value: string) => {
+        limit: (n: number) => { maybeSingle: () => Promise<{ data?: { setting_value?: unknown } }> };
+      };
+    };
+  };
+}
+
+export async function readDbWebhookSecret(
+  supa?: SupabaseLike,
+): Promise<string | null> {
   try {
     if (supa) {
       const { data } = await supa.from("bot_settings")
@@ -26,7 +38,9 @@ export async function readDbWebhookSecret(supa?: any): Promise<string | null> {
     return null;
   }
 }
-export async function expectedSecret(supa?: any): Promise<string | null> {
+export async function expectedSecret(
+  supa?: SupabaseLike,
+): Promise<string | null> {
   return (await readDbWebhookSecret(supa)) || maybe("TELEGRAM_WEBHOOK_SECRET");
 }
 export async function validateTelegramHeader(

--- a/supabase/functions/_tests/env-mock.ts
+++ b/supabase/functions/_tests/env-mock.ts
@@ -1,10 +1,14 @@
 // supabase/functions/_tests/env-mock.ts
 import { EnvKey } from "../_shared/env.ts";
 
+interface TestEnvGlobal {
+  __TEST_ENV__?: Partial<Record<EnvKey, string>>;
+}
+
 export function setTestEnv(values: Partial<Record<EnvKey, string>>) {
-  (globalThis as any).__TEST_ENV__ = { ...values };
+  (globalThis as TestEnvGlobal).__TEST_ENV__ = { ...values };
 }
 
 export function clearTestEnv() {
-  delete (globalThis as any).__TEST_ENV__;
+  delete (globalThis as TestEnvGlobal).__TEST_ENV__;
 }

--- a/supabase/functions/_tests/helpers.ts
+++ b/supabase/functions/_tests/helpers.ts
@@ -1,10 +1,19 @@
 // tiny harness for Edge-function logic
 
-export function setTestEnv(kv: Record<string,string>) {
-  (globalThis as any).__TEST_ENV__ = { ...(globalThis as any).__TEST_ENV__, ...kv };
+interface TestEnvGlobal {
+  __TEST_ENV__?: Record<string, string>;
 }
 
-export async function makeTelegramInitData(user: any, botToken: string, extra: Record<string,string> = {}) {
+export function setTestEnv(kv: Record<string, string>) {
+  const g = globalThis as TestEnvGlobal;
+  g.__TEST_ENV__ = { ...g.__TEST_ENV__, ...kv };
+}
+
+export async function makeTelegramInitData(
+  user: Record<string, unknown>,
+  botToken: string,
+  extra: Record<string, string> = {},
+) {
   // builds a valid WebApp initData for tests
   const enc = new TextEncoder();
   const secretKey = await crypto.subtle.digest("SHA-256", enc.encode(botToken));

--- a/supabase/functions/analytics-collector/index.ts
+++ b/supabase/functions/analytics-collector/index.ts
@@ -51,7 +51,7 @@ serve(async (req) => {
     .gte("updated_at", start).lte("updated_at", end);
 
   const revenue = (pays ?? []).reduce(
-    (s, p: any) => s + (Number(p.amount ?? 0) || 0),
+    (s, p: { amount?: unknown }) => s + (Number(p.amount ?? 0) || 0),
     0,
   );
 
@@ -72,7 +72,7 @@ serve(async (req) => {
   const conversionRates = { simple: commands ? (completed / commands) : 0 };
 
   // top promo codes if table present
-  let topPromoCodes: Record<string, number> = {};
+  const topPromoCodes: Record<string, number> = {};
   try {
     const { data: promos } = await supa.from("promo_analytics")
       .select("promo_code")
@@ -81,7 +81,9 @@ serve(async (req) => {
       const code = p.promo_code || "unknown";
       topPromoCodes[code] = (topPromoCodes[code] ?? 0) + 1;
     }
-  } catch {}
+  } catch {
+    // ignore if promo_analytics table is absent
+  }
 
   // upsert daily_analytics
   await supa.from("daily_analytics").upsert({

--- a/supabase/functions/linkage-audit/index.ts
+++ b/supabase/functions/linkage-audit/index.ts
@@ -12,7 +12,7 @@ function env(k: EnvKey) {
   return optionalEnv(k) ?? "";
 }
 
-async function getWebhookInfo(token?: string): Promise<any> {
+async function getWebhookInfo(token?: string): Promise<Record<string, unknown>> {
   if (!token) return { ok: false, error: "missing_token" };
   try {
     const r = await fetch(

--- a/supabase/functions/miniapp-health/index.ts
+++ b/supabase/functions/miniapp-health/index.ts
@@ -1,7 +1,20 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { getEnv } from "../_shared/env.ts";
 
-export async function getVipForTelegram(supa: any, tg: string): Promise<boolean | null> {
+interface SupabaseLike {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (col: string, value: string) => {
+        limit: (n: number) => Promise<{ data?: Array<Record<string, unknown>>; error?: { message: string } }>;
+      };
+    };
+  };
+}
+
+export async function getVipForTelegram(
+  supa: SupabaseLike,
+  tg: string,
+): Promise<boolean | null> {
   const { data: users, error } = await supa
     .from("bot_users")
     .select("is_vip, subscription_expires_at")
@@ -12,7 +25,10 @@ export async function getVipForTelegram(supa: any, tg: string): Promise<boolean 
   }
   let isVip: boolean | null = null;
   if (users && users.length > 0) {
-    const u = users[0] as any;
+    const u = users[0] as {
+      is_vip?: boolean;
+      subscription_expires_at?: string;
+    };
     if (typeof u.is_vip === "boolean") isVip = u.is_vip;
     if (isVip === null && u.subscription_expires_at) {
       isVip = new Date(u.subscription_expires_at).getTime() >= Date.now();

--- a/supabase/functions/miniapp-smoke/index.ts
+++ b/supabase/functions/miniapp-smoke/index.ts
@@ -17,8 +17,7 @@ serve(async (req) => {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
   }
-  // deno-lint-ignore no-explicit-any
-  let body: any = {};
+  let body: Record<string, unknown> = {};
   try {
     body = await req.json();
   } catch { /* ignore */ }

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -7,7 +7,7 @@ const need = (k: string) =>
     throw new Error(`Missing env ${k}`);
   })();
 
-async function approve(supa: any, paymentId: string, monthsOverride?: number) {
+async function approve(_supa: unknown, paymentId: string, monthsOverride?: number) {
   // Reuse Phase 4 admin flow by calling the endpoint (keeps logic in one place)
   const admin = need("ADMIN_API_SECRET");
   const ref = new URL(need("SUPABASE_URL")).hostname.split(".")[0];
@@ -25,7 +25,7 @@ async function approve(supa: any, paymentId: string, monthsOverride?: number) {
   return { ok: r.ok, j: await r.json().catch(() => ({})) };
 }
 
-function num(x: any) {
+function num(x: unknown) {
   const n = Number(x);
   return isFinite(n) ? n : null;
 }
@@ -64,7 +64,7 @@ serve(async (req) => {
       )
       .eq("status", "pending").gte("created_at", sinceIso).limit(50);
 
-    const results: any[] = [];
+    const results: Array<Record<string, unknown>> = [];
 
     for (const p of pendings || []) {
       const ocr = p.webhook_data?.ocr;

--- a/supabase/functions/subscriptions-cron/index.ts
+++ b/supabase/functions/subscriptions-cron/index.ts
@@ -1,9 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { getEnv } from "../_shared/env.ts";
+import { getEnv, EnvKey } from "../_shared/env.ts";
 
-function need(k: string) {
-  return getEnv(k as any);
+function need(k: EnvKey) {
+  return getEnv(k);
 }
 
 async function tgSend(token: string, chatId: string, text: string) {
@@ -26,10 +26,10 @@ serve(async (_req) => {
   const d1 = new Date(now);
   d1.setDate(now.getDate() + 1);
 
-  let { data: soon7 } = await supa.rpc("get_users_expiring_between", {
+  const { data: soon7 } = await supa.rpc("get_users_expiring_between", {
     start_ts: new Date(d7.setHours(0, 0, 0, 0)).toISOString(),
     end_ts: new Date(d7.setHours(23, 59, 59, 999)).toISOString(),
-  }).catch(() => ({ data: [] as any[] }));
+  }).catch(() => ({ data: [] as Array<Record<string, unknown>> }));
   for (const u of soon7 || []) {
     if (u.telegram_id) {
       await tgSend(
@@ -40,10 +40,10 @@ serve(async (_req) => {
     }
   }
 
-  let { data: soon1 } = await supa.rpc("get_users_expiring_between", {
+  const { data: soon1 } = await supa.rpc("get_users_expiring_between", {
     start_ts: new Date(d1.setHours(0, 0, 0, 0)).toISOString(),
     end_ts: new Date(d1.setHours(23, 59, 59, 999)).toISOString(),
-  }).catch(() => ({ data: [] as any[] }));
+  }).catch(() => ({ data: [] as Array<Record<string, unknown>> }));
   for (const u of soon1 || []) {
     if (u.telegram_id) {
       await tgSend(

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -25,7 +25,16 @@ function genHex(n = 24) {
   return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
 }
 
-async function upsertDbSecret(supa: any, val: string) {
+interface SupaUpsert {
+  from: (table: string) => {
+    upsert: (
+      values: Record<string, unknown>,
+      options: { onConflict: string },
+    ) => Promise<{ error?: { message: string } }>; 
+  };
+}
+
+async function upsertDbSecret(supa: SupaUpsert, val: string) {
   const { error } = await supa.from("bot_settings").upsert({
     setting_key: "TELEGRAM_WEBHOOK_SECRET",
     setting_value: val,
@@ -99,7 +108,7 @@ serve(async (req) => {
   if (!secret) mismatches.push("webhook_secret_missing");
 
   // 5) Optional fixes
-  const actions: any[] = [];
+  const actions: Array<Record<string, unknown>> = [];
   if (fix) {
     // Ensure we have a secret
     if (!secret) {

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -37,7 +37,7 @@ async function preview(): Promise<{ data: FlagMap }> {
       .like("setting_key", `${FLAG_PREFIX}%`);
     if (error) throw error;
     const map: FlagMap = {};
-    for (const row of (data as any[]) ?? []) {
+    for (const row of (data as Array<Record<string, unknown>>) ?? []) {
       const key: string = (row.setting_key as string) || "";
       const valRaw: string = String(row.setting_value ?? "");
       const normalized = valRaw.toLowerCase();


### PR DESCRIPTION
## Summary
- replace remaining `any` usage with typed structures across app, functions, and scripts
- tighten regex patterns and remove empty catch blocks
- add local interfaces for Supabase and Telegram helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae70b2a588322880122a7f5e1f013