### PR TITLE
Disable JWT verification for miniapp function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,3 +56,6 @@ verify_jwt = false
 
 [functions.tg-verify-init]
 verify_jwt = false
+
+[functions.miniapp]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- disable JWT verification for the `miniapp` edge function so Telegram mini app assets serve without auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b14753fc08322a5c21d9032698235