### PR TITLE
fix: serve miniapp routes without 404

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { mna, ok, nf } from "../_shared/http.ts";
+import { mna, ok } from "../_shared/http.ts";
 
 const cache = new Map<string, Response>();
 const SECURITY = {
@@ -104,7 +104,9 @@ serve(async (req) => {
     const rel = url.pathname.replace(/^\//, "");
     resp = await file(rel, TYPE(rel));
   } else {
-    resp = nf("Not Found");
+    // For SPA routes (e.g. /dashboard, /signals), serve index.html
+    // so client-side routing can handle the path.
+    resp = await indexHtml();
   }
   const h = new Headers(resp.headers);
   h.set("referrer-policy", "strict-origin-when-cross-origin");


### PR DESCRIPTION
## Summary
- handle unknown miniapp paths by serving index.html for SPA routing

## Testing
- `SUPABASE_ACCESS_TOKEN=sbp_4001f474262d403b74d91908cc37308d8f2762ed npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b85744c288322a2012cc4a9d39d5b