### PR TITLE
Enforce webhook secret validation and secure sync audit

### DIFF
--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set("MINI_APP_URL", "https://example.com/app");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -13,7 +14,10 @@ Deno.test("webhook handles /start with params", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start deep", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);
@@ -35,6 +39,7 @@ Deno.test("webhook uses short name when URL absent", async () => {
   Deno.env.delete("MINI_APP_URL");
   Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -45,7 +50,10 @@ Deno.test("webhook uses short name when URL absent", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);
@@ -64,6 +72,7 @@ Deno.test("webhook uses short name when URL absent", async () => {
 Deno.test("webhook falls back for invalid mini app url", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set("MINI_APP_URL", "http://invalid-url");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -74,7 +83,10 @@ Deno.test("webhook falls back for invalid mini app url", async () => {
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
       body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
     });
     const res = await mod.handler(req);


### PR DESCRIPTION
## Summary
- tighten Telegram webhook secret handling and expose a public version/echo check
- add admin secret requirement for sync-audit endpoint
- ensure webhook secret lookup uses boolean is_active flag

## Testing
- `npm test`
- `npx supabase login --token "$SUPABASE_ACCESS_TOKEN"`
- `npx supabase secrets set TELEGRAM_WEBHOOK_SECRET="$SECRET_HEX" --project-ref qeejuomcapbdlhnjqjcc`
- `curl https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook ...` *(fails: TELEGRAM_BOT_TOKEN not set)*
- `npx supabase functions deploy miniapp --project-ref qeejuomcapbdlhnjqjcc`
- `npx supabase functions deploy telegram-bot --project-ref qeejuomcapbdlhnjqjcc`
- `curl` smoke tests (`mini=200 mini404=404 miniHEAD=200 botNoHdr=401 botWrong=401 botVersion=200`)
- `npx supabase link --project-ref qeejuomcapbdlhnjqjcc` *(fails: network is unreachable)
- `npx supabase functions logs --function miniapp --since 15m` *(fails: unknown flag)
- `npx supabase functions logs --function telegram-bot --since 15m` *(fails: unknown flag)


------
https://chatgpt.com/codex/tasks/task_e_689bb4f4af70832299e1112e65d871df