### PR TITLE
Enforce valid payment statuses and add constraint

### DIFF
--- a/docs/PHASE_4_ADMIN.md
+++ b/docs/PHASE_4_ADMIN.md
@@ -29,5 +29,5 @@ Then pass that string to `/verify-initdata` to confirm the signature and admin c
 
 - Approve: marks payment completed, extends expiry from current expiry or now,
   sets is_vip=true, logs to admin_logs, notifies user.
-- Reject: marks payment rejected, logs, notifies user.
+- Reject: marks payment failed, logs, notifies user.
 - Cron: reminders + auto-expire + logs.

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -181,7 +181,7 @@ interface Payment {
   user_id: string; // Links to bot_users
   plan_id: string; // Links to subscription_plans
   amount: number; // Payment amount
-  status: "pending" | "completed" | "failed"; // Payment status
+  status: "pending" | "completed" | "failed" | "refunded"; // Payment status
   payment_method: string; // "binance_pay", "manual", etc.
 }
 

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -300,7 +300,7 @@ export function UserManagement() {
       const { error } = await supabase
         .from("user_subscriptions")
         .update({
-          payment_status: approve ? "approved" : "rejected",
+          payment_status: approve ? "completed" : "failed",
           is_active: approve,
           subscription_start_date: approve ? new Date().toISOString() : null,
           subscription_end_date: approve
@@ -314,7 +314,7 @@ export function UserManagement() {
       toast({
         title: "Success",
         description: `Payment ${
-          approve ? "approved" : "rejected"
+          approve ? "completed" : "failed"
         } successfully`,
       });
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -800,7 +800,7 @@ export type Database = {
           payment_method: string
           payment_provider_id: string | null
           plan_id: string
-          status: string
+          status: "pending" | "completed" | "failed" | "refunded"
           updated_at: string
           user_id: string
           webhook_data: Json | null
@@ -813,7 +813,7 @@ export type Database = {
           payment_method: string
           payment_provider_id?: string | null
           plan_id: string
-          status?: string
+          status?: "pending" | "completed" | "failed" | "refunded"
           updated_at?: string
           user_id: string
           webhook_data?: Json | null
@@ -826,7 +826,7 @@ export type Database = {
           payment_method?: string
           payment_provider_id?: string | null
           plan_id?: string
-          status?: string
+          status?: "pending" | "completed" | "failed" | "refunded"
           updated_at?: string
           user_id?: string
           webhook_data?: Json | null

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -31,17 +31,17 @@ serve(async (req) => {
   if (!user) return nf("User not found");
 
   if (body.decision === "reject") {
-    await supa.from("payments").update({ status: "rejected" }).eq("id", p.id);
-    if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `❌ <b>Payment Rejected</b>\n${body.message || "Please contact support."}`);
+    await supa.from("payments").update({ status: "failed" }).eq("id", p.id);
+    if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `❌ <b>Payment Failed</b>\\n${body.message || "Please contact support."}`);
     await supa.from("admin_logs").insert({
       admin_telegram_id: String(u.id),
-      action_type: "payment_rejected",
-      action_description: `Payment ${p.id} rejected`,
+      action_type: "payment_failed",
+      action_description: `Payment ${p.id} marked as failed`,
       affected_table: "payments",
       affected_record_id: p.id,
-      new_values: { status: "rejected" }
+      new_values: { status: "failed" }
     });
-    return ok({ status: "rejected" });
+    return ok({ status: "failed" });
   }
 
   // approve

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -80,23 +80,23 @@ serve(async (req) => {
     : null;
 
   if (body.decision === "reject") {
-    newStatus = "rejected";
+    newStatus = "failed";
     await supa.from("payments").update({ status: newStatus }).eq("id", p.id);
 
     if (prof.telegram_id) {
       const msg = body.message ||
-        "Your payment was rejected. Please contact support.";
+        "Your payment failed. Please contact support.";
       await tgSend(
         botToken,
         String(prof.telegram_id),
-        `❌ <b>Payment Rejected</b>\n${msg}`,
+        `❌ <b>Payment Failed</b>\\n${msg}`,
       );
     }
 
     await supa.from("admin_logs").insert({
       admin_telegram_id: adminId || "unknown",
-      action_type: "payment_rejected",
-      action_description: `Payment ${p.id} rejected`,
+      action_type: "payment_failed",
+      action_description: `Payment ${p.id} marked as failed`,
       affected_table: "payments",
       affected_record_id: p.id,
       new_values: { status: newStatus },

--- a/supabase/migrations/20250814090000_add_payment_status_check.sql
+++ b/supabase/migrations/20250814090000_add_payment_status_check.sql
@@ -1,0 +1,20 @@
+-- Backfill existing payment statuses and enforce valid values
+UPDATE public.payments
+SET status = CASE
+    WHEN status IN ('approved') THEN 'completed'
+    WHEN status IN ('rejected', 'cancelled') THEN 'failed'
+    WHEN status IS NULL OR status = '' THEN 'pending'
+    ELSE status
+END;
+
+-- Default any remaining invalid statuses to 'pending'
+UPDATE public.payments
+SET status = 'pending'
+WHERE status NOT IN ('pending','completed','failed','refunded');
+
+-- Add CHECK constraint for allowed statuses
+ALTER TABLE public.payments
+  DROP CONSTRAINT IF EXISTS payments_status_check;
+ALTER TABLE public.payments
+  ADD CONSTRAINT payments_status_check
+  CHECK (status IN ('pending','completed','failed','refunded'));

--- a/types/telegram-bot.ts
+++ b/types/telegram-bot.ts
@@ -100,7 +100,7 @@ export interface UserSubscription {
   telegram_user_id: string;
   plan_id?: string;
   is_active: boolean;
-  payment_status: "pending" | "completed" | "failed" | "cancelled";
+  payment_status: PaymentStatus;
   payment_method?: string;
   subscription_start_date?: string;
   subscription_end_date?: string;
@@ -121,7 +121,7 @@ export interface Payment {
   currency: string;
   payment_method: string;
   payment_provider_id?: string;
-  status: "pending" | "completed" | "failed" | "cancelled";
+  status: PaymentStatus;
   webhook_data?: Record<string, unknown>;
   created_at: string;
   updated_at: string;
@@ -170,7 +170,7 @@ export interface EducationEnrollment {
   student_email?: string;
   student_phone?: string;
   enrollment_status: "pending" | "active" | "completed" | "cancelled";
-  payment_status: "pending" | "completed" | "failed";
+  payment_status: PaymentStatus;
   payment_method?: string;
   payment_amount?: number;
   payment_reference?: string;
@@ -481,7 +481,19 @@ export type DatabaseTable =
   | "broadcast_messages"
   | "admin_logs";
 
-export type PaymentStatus = "pending" | "completed" | "failed" | "cancelled";
+export const PAYMENT_STATUSES = [
+  "pending",
+  "completed",
+  "failed",
+  "refunded",
+] as const;
+export type PaymentStatus = (typeof PAYMENT_STATUSES)[number];
+
+export function isValidPaymentStatus(
+  status: string,
+): status is PaymentStatus {
+  return (PAYMENT_STATUSES as readonly string[]).includes(status);
+}
 export type SubscriptionStatus = "pending" | "active" | "expired" | "cancelled";
 export type BroadcastStatus =
   | "draft"


### PR DESCRIPTION
## Summary
- add check constraint on `payments.status` and backfill invalid entries
- introduce `PaymentStatus` enum with helper validation
- update admin payment flows to use `completed`/`failed` statuses

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6cf82a2483228aa616f1f6cb5871