### PR TITLE
Add indexes for foreign key columns

### DIFF
--- a/supabase/migrations/20250815000000_add_foreign_key_indexes.sql
+++ b/supabase/migrations/20250815000000_add_foreign_key_indexes.sql
@@ -1,0 +1,6 @@
+-- Add indexes on foreign key columns to improve join performance
+CREATE INDEX IF NOT EXISTS idx_promo_analytics_plan_id ON public.promo_analytics(plan_id);
+CREATE INDEX IF NOT EXISTS idx_user_surveys_recommended_plan_id ON public.user_surveys(recommended_plan_id);
+CREATE INDEX IF NOT EXISTS idx_education_enrollments_package_id ON public.education_enrollments(package_id);
+CREATE INDEX IF NOT EXISTS idx_education_enrollments_student_bot_user_id ON public.education_enrollments(student_bot_user_id);
+CREATE INDEX IF NOT EXISTS idx_promotion_usage_promotion_id ON public.promotion_usage(promotion_id);


### PR DESCRIPTION
## Summary
- index foreign key columns used in joins

## Testing
- `npm test`
- `EXPLAIN ANALYZE SELECT * FROM promotion_usage WHERE promotion_id = 'b95e477f-b322-4d5e-92c4-1cfc3e6aa066';` before and after indexing


------
https://chatgpt.com/codex/tasks/task_e_689c6cfb94e48322a5bb1439cb3296cf