### PR TITLE
feat: centralize updated_at handling with trigger

### DIFF
--- a/src/components/admin/BotSettings.tsx
+++ b/src/components/admin/BotSettings.tsx
@@ -62,7 +62,6 @@ export const BotSettings = () => {
         .from("bot_settings")
         .update({
           setting_value: newValue,
-          updated_at: new Date().toISOString(),
         })
         .eq("setting_key", settingKey);
 

--- a/src/components/admin/WelcomeMessageEditor.tsx
+++ b/src/components/admin/WelcomeMessageEditor.tsx
@@ -151,7 +151,6 @@ export const WelcomeMessageEditor = () => {
         .update({
           content_value: editedMessage,
           last_modified_by: "admin",
-          updated_at: new Date().toISOString(),
         })
         .eq("id", welcomeMessage.id);
 
@@ -161,11 +160,10 @@ export const WelcomeMessageEditor = () => {
       setWelcomeMessage((prev) =>
         prev
           ? {
-            ...prev,
-            content_value: editedMessage,
-            updated_at: new Date().toISOString(),
-            last_modified_by: "admin",
-          }
+              ...prev,
+              content_value: editedMessage,
+              last_modified_by: "admin",
+            }
           : null
       );
 

--- a/supabase/functions/binance-pay-webhook/index.ts
+++ b/supabase/functions/binance-pay-webhook/index.ts
@@ -116,7 +116,6 @@ serve(async (req) => {
           status: "completed",
           payment_provider_id: transactionId,
           webhook_data: webhookData,
-          updated_at: new Date().toISOString(),
         })
         .eq("id", merchantTradeNo);
 
@@ -164,7 +163,6 @@ serve(async (req) => {
           is_vip: true,
           current_plan_id: payment.plan_id,
           subscription_expires_at: endDate.toISOString(),
-          updated_at: new Date().toISOString(),
         })
         .eq("telegram_id", payment.user_id);
 
@@ -179,7 +177,6 @@ serve(async (req) => {
           is_active: true,
           payment_status: "completed",
           payment_method: "binance_pay",
-          updated_at: new Date().toISOString(),
         });
 
       // Send success message to user via Telegram bot
@@ -237,7 +234,6 @@ serve(async (req) => {
                 telegram_user_id: payment.user_id,
                 is_active: true,
                 created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
                 added_at: new Date().toISOString(),
               }));
 

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1085,7 +1085,6 @@ export async function handleTogglePlanLifetime(
     const updateData = {
       is_lifetime: newLifetimeStatus,
       duration_months: newLifetimeStatus ? 0 : (plan.duration_months || 1),
-      updated_at: new Date().toISOString(),
     };
 
     const { error: updateError } = await supabaseAdmin

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -181,7 +181,6 @@ export async function setBotContent(
         content_key: contentKey,
         content_value: contentValue,
         last_modified_by: adminId,
-        updated_at: new Date().toISOString(),
       }, {
         onConflict: "content_key",
       });
@@ -236,7 +235,6 @@ export async function setBotSetting(
       .upsert({
         setting_key: settingKey,
         setting_value: settingValue,
-        updated_at: new Date().toISOString(),
       });
 
     if (!error) {
@@ -285,11 +283,10 @@ export async function resetBotSettings(
   adminId: string,
 ): Promise<boolean> {
   try {
-    const rows = Object.entries(defaultSettings).map(([key, value]) => ({
-      setting_key: key,
-      setting_value: value,
-      updated_at: new Date().toISOString(),
-    }));
+  const rows = Object.entries(defaultSettings).map(([key, value]) => ({
+    setting_key: key,
+    setting_value: value,
+  }));
 
     const { error } = await supabaseAdmin
       .from("bot_settings")
@@ -503,10 +500,9 @@ export async function processPlaneEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-          .update({
-            price: price,
-            updated_at: new Date().toISOString(),
-          })
+        .update({
+          price: price,
+        })
           .eq("id", planId);
 
         if (error) {
@@ -542,10 +538,9 @@ export async function processPlaneEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-          .update({
-            name: name,
-            updated_at: new Date().toISOString(),
-          })
+        .update({
+          name: name,
+        })
           .eq("id", planId);
 
         if (error) {
@@ -592,11 +587,10 @@ export async function processPlaneEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-          .update({
-            duration_months: durationMonths,
-            is_lifetime: isLifetime,
-            updated_at: new Date().toISOString(),
-          })
+        .update({
+          duration_months: durationMonths,
+          is_lifetime: isLifetime,
+        })
           .eq("id", planId);
 
         if (error) {
@@ -653,10 +647,9 @@ export async function processPlaneEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-          .update({
-            features: updatedFeatures,
-            updated_at: new Date().toISOString(),
-          })
+        .update({
+          features: updatedFeatures,
+        })
           .eq("id", planId);
 
         if (error) {
@@ -1010,7 +1003,6 @@ export async function updateUserActivity(
       .from("bot_users")
       .upsert({
         telegram_id: telegramUserId,
-        updated_at: new Date().toISOString(),
         follow_up_count: 0, // Reset follow-up count on activity
       }, {
         onConflict: "telegram_id",

--- a/supabase/migrations/20250814000000_handle_updated_at_trigger.sql
+++ b/supabase/migrations/20250814000000_handle_updated_at_trigger.sql
@@ -1,0 +1,43 @@
+-- Create a shared trigger function for automatic updated_at maintenance
+CREATE OR REPLACE FUNCTION public.handle_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop existing triggers that use the old update_updated_at_column function
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN (
+    SELECT trigger_name, event_object_schema, event_object_table
+    FROM information_schema.triggers
+    WHERE action_statement LIKE '%update_updated_at_column%'
+  ) LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I.%I;', r.trigger_name, r.event_object_schema, r.event_object_table);
+  END LOOP;
+END $$;
+
+-- Attach the shared trigger to all tables that have an updated_at column
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN (
+    SELECT c.table_schema, c.table_name
+    FROM information_schema.columns c
+    JOIN information_schema.tables t ON c.table_schema = t.table_schema AND c.table_name = t.table_name
+    WHERE c.column_name = 'updated_at'
+      AND t.table_type = 'BASE TABLE'
+      AND c.table_schema = 'public'
+  ) LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS handle_updated_at ON %I.%I;', r.table_schema, r.table_name);
+    EXECUTE format('CREATE TRIGGER handle_updated_at BEFORE UPDATE ON %I.%I FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();', r.table_schema, r.table_name);
+  END LOOP;
+END $$;
+
+-- Remove the old trigger function if it exists
+DROP FUNCTION IF EXISTS public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- add shared `handle_updated_at` trigger and attach to tables automatically
- remove manual `updated_at` field updates in admin UI and Supabase functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6d03d1788322877dc3f9b8bfe5d7