### PR TITLE
Use PostgreSQL enums for trigger and content types

### DIFF
--- a/src/components/admin/WelcomeMessageEditor.tsx
+++ b/src/components/admin/WelcomeMessageEditor.tsx
@@ -26,7 +26,7 @@ interface WelcomeContent {
   id: string;
   content_key: string;
   content_value: string;
-  content_type: string;
+  content_type: "text" | "html" | "markdown";
   description: string;
   is_active: boolean;
   updated_at: string;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -59,7 +59,7 @@ export type Database = {
           is_active: boolean
           message_template: string
           name: string
-          trigger_type: string
+            trigger_type: Database["public"]["Enums"]["trigger_type_enum"]
           updated_at: string
         }
         Insert: {
@@ -70,7 +70,7 @@ export type Database = {
           is_active?: boolean
           message_template: string
           name: string
-          trigger_type: string
+            trigger_type: Database["public"]["Enums"]["trigger_type_enum"]
           updated_at?: string
         }
         Update: {
@@ -81,7 +81,7 @@ export type Database = {
           is_active?: boolean
           message_template?: string
           name?: string
-          trigger_type?: string
+            trigger_type?: Database["public"]["Enums"]["trigger_type_enum"]
           updated_at?: string
         }
         Relationships: []
@@ -125,7 +125,7 @@ export type Database = {
       bot_content: {
         Row: {
           content_key: string
-          content_type: string
+            content_type: Database["public"]["Enums"]["content_type_enum"]
           content_value: string
           created_at: string
           created_by: string | null
@@ -137,7 +137,7 @@ export type Database = {
         }
         Insert: {
           content_key: string
-          content_type?: string
+            content_type?: Database["public"]["Enums"]["content_type_enum"]
           content_value: string
           created_at?: string
           created_by?: string | null
@@ -149,7 +149,7 @@ export type Database = {
         }
         Update: {
           content_key?: string
-          content_type?: string
+            content_type?: Database["public"]["Enums"]["content_type_enum"]
           content_value?: string
           created_at?: string
           created_by?: string | null
@@ -1375,7 +1375,8 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      content_type_enum: "text" | "html" | "markdown"
+      trigger_type_enum: "keyword" | "regex" | "command"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20250814000000_add_content_and_trigger_enums.sql
+++ b/supabase/migrations/20250814000000_add_content_and_trigger_enums.sql
@@ -1,0 +1,22 @@
+-- Create enum types for content and trigger types
+DO $$ BEGIN
+    CREATE TYPE content_type_enum AS ENUM ('text', 'html', 'markdown');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE trigger_type_enum AS ENUM ('keyword', 'regex', 'command');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Alter bot_content.content_type to use content_type_enum
+aLTER TABLE bot_content
+    ALTER COLUMN content_type DROP DEFAULT,
+    ALTER COLUMN content_type TYPE content_type_enum USING content_type::content_type_enum,
+    ALTER COLUMN content_type SET DEFAULT 'text';
+
+-- Alter auto_reply_templates.trigger_type to use trigger_type_enum
+ALTER TABLE auto_reply_templates
+    ALTER COLUMN trigger_type TYPE trigger_type_enum USING trigger_type::trigger_type_enum;


### PR DESCRIPTION
## Summary
- add enum definitions for `content_type` and `trigger_type`
- switch related columns to use new enums
- align TypeScript interfaces with enum values

## Testing
- `npm test` *(fails: deno not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6d0a48c8832290b28fff63a94223