### PR TITLE
refactor: centralize env access

### DIFF
--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { ok, bad, nf, mna, unauth } from "../_shared/http.ts";
+import { requireEnv } from "../_shared/env.ts";
 
 type Body = { initData: string; payment_id: string; decision: "approve"|"reject"; months?: number; message?: string };
 
@@ -19,9 +20,8 @@ serve(async (req) => {
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return unauth();
 
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-  const bot = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
+  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc, TELEGRAM_BOT_TOKEN: bot } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TELEGRAM_BOT_TOKEN"] as const);
   const supa = createClient(url, svc, { auth: { persistSession: false } });
 
   // Load payment + user + plan

--- a/supabase/functions/admin-bans/index.ts
+++ b/supabase/functions/admin-bans/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { isAdmin, verifyInitDataAndGetUser } from "../_shared/telegram.ts";
+import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") {
@@ -24,9 +25,11 @@ serve(async (req) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
   const supa = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
     { auth: { persistSession: false } },
   );
 

--- a/supabase/functions/admin-list-pending/index.ts
+++ b/supabase/functions/admin-list-pending/index.ts
@@ -1,13 +1,14 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
   let body: { initData?: string; limit?: number; offset?: number }; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
 
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const srv = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: srv } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
   const supa = createClient(url, srv, { auth: { persistSession: false } });
 
   const u = await verifyInitDataAndGetUser(body.initData || "");

--- a/supabase/functions/admin-logs/index.ts
+++ b/supabase/functions/admin-logs/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
+import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
@@ -9,8 +10,8 @@ serve(async (req) => {
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
 
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
   const supa = createClient(url, svc, { auth: { persistSession: false } });
 
   const limit = Math.min(Math.max(body.limit ?? 20, 1), 100);

--- a/supabase/functions/analytics-collector/index.ts
+++ b/supabase/functions/analytics-collector/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { ok } from "../_shared/http.ts";
+import { getEnv } from "../_shared/env.ts";
 
 function svc() {
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const url = getEnv("SUPABASE_URL");
+  const key = getEnv("SUPABASE_SERVICE_ROLE_KEY");
   return createClient(url, key, { auth: { persistSession: false } });
 }
 function isoDay(d: Date) {

--- a/supabase/functions/binancepay-webhook/index.ts
+++ b/supabase/functions/binancepay-webhook/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") {
@@ -16,9 +17,11 @@ serve(async (req) => {
   // Example: locate payment by payment_provider_id from your checkout-init step
   const providerId = body?.merchantTradeNo || body?.prepayId || null;
 
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
   const supa = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
     { auth: { persistSession: false } },
   );
 

--- a/supabase/functions/data-retention-cron/index.ts
+++ b/supabase/functions/data-retention-cron/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { ok } from "../_shared/http.ts";
+import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   const url = new URL(req.url);
@@ -8,9 +9,11 @@ serve(async (req) => {
     return ok({ name: "data-retention-cron", ts: new Date().toISOString() });
   }
   if (req.method === "HEAD") return new Response(null, { status: 200 });
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
+    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
   const supa = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
     { auth: { persistSession: false } },
   );
   const days = Number(Deno.env.get("RETENTION_DAYS") ?? "90");

--- a/supabase/functions/ops-health/index.ts
+++ b/supabase/functions/ops-health/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getEnv } from "../_shared/env.ts";
 
 serve(async (_req) => {
   const report: Record<string, unknown> = { ok: true, checks: {} };
@@ -23,8 +24,8 @@ serve(async (_req) => {
   // DB ping
   try {
     const supa = createClient(
-      Deno.env.get("SUPABASE_URL")!,
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+      getEnv("SUPABASE_URL"),
+      getEnv("SUPABASE_SERVICE_ROLE_KEY"),
       { auth: { persistSession: false } },
     );
     const { data, error } = await supa.from("bot_users").select("id").limit(1);

--- a/supabase/functions/rotate-webhook-secret/index.ts
+++ b/supabase/functions/rotate-webhook-secret/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { ok, mna, unauth, oops } from "../_shared/http.ts";
+import { requireEnv } from "../_shared/env.ts";
 
 function genHex(n = 24) {
   const b = new Uint8Array(n);
@@ -33,10 +34,9 @@ serve(async (req) => {
       return unauth();
     }
 
-    const url = Deno.env.get("SUPABASE_URL")!,
-      svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc, TELEGRAM_BOT_TOKEN: token } =
+      requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TELEGRAM_BOT_TOKEN"] as const);
     const supa = createClient(url, svc, { auth: { persistSession: false } });
-    const token = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
     const ref = (new URL(url)).hostname.split(".")[0];
     const expectedUrl = `https://${ref}.functions.supabase.co/telegram-bot`;
 

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1,4 +1,4 @@
-import { optionalEnv } from "../_shared/env.ts";
+import { optionalEnv, getEnv } from "../_shared/env.ts";
 import { requireEnv as requireEnvCheck } from "./helpers/require-env.ts";
 import { alertAdmins } from "../_shared/alerts.ts";
 import { json, mna, ok, oops } from "../_shared/http.ts";
@@ -197,8 +197,8 @@ function logEvent(event: string, data: Record<string, unknown>): void {
 }
 
 function supaSvc() {
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const url = getEnv("SUPABASE_URL");
+  const key = getEnv("SUPABASE_SERVICE_ROLE_KEY");
   return createClient(url, key, { auth: { persistSession: false } });
 }
 
@@ -576,8 +576,8 @@ export async function serveWebhook(req: Request): Promise<Response> {
 
     // ---- BAN CHECK (short-circuit early) ----
     const supa = createClient(
-      Deno.env.get("SUPABASE_URL")!,
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+      getEnv("SUPABASE_URL"),
+      getEnv("SUPABASE_SERVICE_ROLE_KEY"),
       { auth: { persistSession: false } },
     );
     const fromId = String(


### PR DESCRIPTION
## Summary
- replace direct `Deno.env.get(...)!` calls in Supabase functions with shared `getEnv`/`requireEnv`
- ensure missing environment variables throw descriptive errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c72dfd3508322965f9e8c97518c3c