### PR TITLE
chore: use text arrays for education packages

### DIFF
--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -102,6 +102,7 @@ export function UserManagement() {
     package_id: "",
     expires_at: "",
     notes: "",
+    telegram_channels: [] as string[],
   });
 
   const loadData = useCallback(async () => {
@@ -135,7 +136,14 @@ export function UserManagement() {
         .order("assigned_at", { ascending: false });
 
       if (!assignmentsResponse.error) {
-        setAssignments((assignmentsResponse.data as PackageAssignment[]) || []);
+        const data = (assignmentsResponse.data as PackageAssignment[]) || [];
+        // Ensure telegram_channels is always an array
+        setAssignments(
+          data.map((a) => ({
+            ...a,
+            telegram_channels: a.telegram_channels || [],
+          })),
+        );
       }
     } catch (error) {
       console.error("Error loading data:", error);

--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -73,7 +73,15 @@ const Education: React.FC = () => {
       if (packagesError) throw packagesError;
 
       setCategories(categoriesData || []);
-      setPackages(packagesData || []);
+      // Normalize array fields to always be arrays
+      setPackages(
+        (packagesData || []).map((pkg) => ({
+          ...pkg,
+          features: pkg.features || [],
+          requirements: pkg.requirements || [],
+          learning_outcomes: pkg.learning_outcomes || [],
+        })),
+      );
     } catch (error) {
       console.error("Error fetching education data:", error);
       toast({

--- a/supabase/migrations/20250814000000_use_text_arrays.sql
+++ b/supabase/migrations/20250814000000_use_text_arrays.sql
@@ -1,0 +1,50 @@
+-- Ensure array fields use text[] for education packages and user package assignments
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='education_packages'
+      AND column_name='features'
+      AND data_type <> 'ARRAY'
+  ) THEN
+    ALTER TABLE public.education_packages
+      ALTER COLUMN features TYPE text[] USING
+        CASE
+          WHEN features IS NULL THEN ARRAY[]::text[]
+          WHEN pg_typeof(features)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(features))
+          ELSE string_to_array(features::text, ',')
+        END,
+      ALTER COLUMN requirements TYPE text[] USING
+        CASE
+          WHEN requirements IS NULL THEN ARRAY[]::text[]
+          WHEN pg_typeof(requirements)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(requirements))
+          ELSE string_to_array(requirements::text, ',')
+        END,
+      ALTER COLUMN learning_outcomes TYPE text[] USING
+        CASE
+          WHEN learning_outcomes IS NULL THEN ARRAY[]::text[]
+          WHEN pg_typeof(learning_outcomes)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(learning_outcomes))
+          ELSE string_to_array(learning_outcomes::text, ',')
+        END;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='user_package_assignments'
+      AND column_name='telegram_channels'
+      AND data_type <> 'ARRAY'
+  ) THEN
+    ALTER TABLE public.user_package_assignments
+      ALTER COLUMN telegram_channels TYPE text[] USING
+        CASE
+          WHEN telegram_channels IS NULL THEN ARRAY[]::text[]
+          WHEN pg_typeof(telegram_channels)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(telegram_channels))
+          ELSE string_to_array(telegram_channels::text, ',')
+        END;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- ensure education package arrays stored as text[]
- normalize array fields in education and user management views

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c72ea7d64832293581b7de3cd09fc