### PR TITLE
Enforce canonical payment status values

### DIFF
--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -66,8 +66,8 @@ serve(async (req) => {
   if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `✅ <b>VIP Activated</b>\nValid until <b>${new Date(expiresAt).toLocaleDateString()}</b>.`);
   await supa.from("admin_logs").insert({
     admin_telegram_id: String(u.id),
-    action_type: "payment_approved",
-    action_description: `Payment ${p.id} approved; VIP until ${expiresAt}`,
+    action_type: "payment_completed",
+    action_description: `Payment ${p.id} completed; VIP until ${expiresAt}`,
     affected_table: "bot_users", affected_record_id: user.id,
     new_values: { is_vip: true, subscription_expires_at: expiresAt }
   });

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -155,8 +155,8 @@ serve(async (req) => {
 
   await supa.from("admin_logs").insert({
     admin_telegram_id: adminId || "unknown",
-    action_type: "payment_approved",
-    action_description: `Payment ${p.id} approved; VIP until ${expiresAt}`,
+    action_type: "payment_completed",
+    action_description: `Payment ${p.id} completed; VIP until ${expiresAt}`,
     affected_table: "bot_users",
     affected_record_id: prof.id,
     new_values: { is_vip: true, subscription_expires_at: expiresAt },

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -7,7 +7,11 @@ const need = (k: string) =>
     throw new Error(`Missing env ${k}`);
   })();
 
-async function approve(_supa: unknown, paymentId: string, monthsOverride?: number) {
+async function completePayment(
+  _supa: unknown,
+  paymentId: string,
+  monthsOverride?: number,
+) {
   // Reuse Phase 4 admin flow by calling the endpoint (keeps logic in one place)
   const admin = need("ADMIN_API_SECRET");
   const ref = new URL(need("SUPABASE_URL")).hostname.split(".")[0];
@@ -126,14 +130,14 @@ serve(async (req) => {
       if (pass) {
         await supa.from("admin_logs").insert({
           admin_telegram_id: "system",
-          action_type: "auto_approve",
+          action_type: "auto_complete",
           action_description:
-            `Auto-approved payment ${p.id} via ${p.payment_method} (${reason})`,
+            `Auto-completed payment ${p.id} via ${p.payment_method} (${reason})`,
           affected_table: "payments",
           affected_record_id: p.id,
         });
-        const okr = await approve(supa, p.id);
-        results.push({ id: p.id, action: "approved", ok: okr.ok });
+        const okr = await completePayment(supa, p.id);
+        results.push({ id: p.id, action: "completed", ok: okr.ok });
       } else {
         results.push({
           id: p.id,


### PR DESCRIPTION
## Summary
- use canonical `completed` status in admin action logs
- surface auto-review results and logs with canonical `completed` status
- ensure payment status normalization and check constraint via migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c72ee6d488322965b3404ba64ad76