### PR TITLE
Ensure webhook secret is enforced

### DIFF
--- a/scripts/telegram-webhook.sh
+++ b/scripts/telegram-webhook.sh
@@ -52,7 +52,8 @@ case "$cmd" in
     echo "[+] Setting webhook (URL hidden)..."
     # Do not echo the full URL to avoid leaking secrets
     curl -sS -X POST "${API_BASE}/setWebhook" \
-      -d "url=${FUNCTION_URL}?secret=${TELEGRAM_WEBHOOK_SECRET}" | jq -r '.description // "ok"'
+      -d "url=${FUNCTION_URL}?secret=${TELEGRAM_WEBHOOK_SECRET}" \
+      -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" | jq -r '.description // "ok"'
     ;;
   info)
     echo "[i] Webhook info:"


### PR DESCRIPTION
## Summary
- enforce presence of TELEGRAM_WEBHOOK_SECRET via database or env before configuring webhooks
- pass secret via secret_token and query parameter when calling Telegram's setWebhook
- extend telegram-webhook.sh to include secret_token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c98f225d48322ad550983c9589dd1