### PR TITLE
Warn when TELEGRAM_BOT_TOKEN missing

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -97,7 +97,12 @@ async function sendMessage(
   text: string,
   extra: Record<string, unknown> = {},
 ): Promise<void> {
-  if (!BOT_TOKEN) return;
+  if (!BOT_TOKEN) {
+    console.warn(
+      "TELEGRAM_BOT_TOKEN is not set; cannot send message",
+    );
+    return;
+  }
   try {
     const r = await fetch(
       `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`,

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -34,7 +34,12 @@ async function sendMessage(
   extra?: Record<string, unknown>,
 ) {
   const token = optionalEnv("TELEGRAM_BOT_TOKEN");
-  if (!token) return;
+  if (!token) {
+    baseLogger.warn(
+      "TELEGRAM_BOT_TOKEN is not set; cannot send message",
+    );
+    return;
+  }
   try {
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- log a warning when TELEGRAM_BOT_TOKEN is missing in sendMessage helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c98f1e39083228f8f8b729622372c