### PR TITLE
Standardize Telegram webhook secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ supabase start
 supabase functions serve telegram-bot --no-verify-jwt
 
 # Ping (expects 200)
-curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
-  -H "content-type: application/json" -d '{"test":"ping"}'
+curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot" \
+  -H "content-type: application/json" \
+  -H "X-Telegram-Bot-Api-Secret-Token: $TELEGRAM_WEBHOOK_SECRET" \
+  -d '{"test":"ping"}'
 ```
 
 Note: for OCR parsing, send an actual Telegram image to the bot; OCR runs only
@@ -89,7 +91,8 @@ deno test -A
 
 ## Deployment
 
-See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for environment vars, tests, deployment, and troubleshooting.
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for environment vars, tests,
+deployment, and troubleshooting.
 
 Deploy function:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,8 @@
 
 ## Environment variables
 
-Essential settings for the bot and Edge Functions. See [env.md](env.md) for a full list and usage notes.
+Essential settings for the bot and Edge Functions. See [env.md](env.md) for a
+full list and usage notes.
 
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
@@ -31,7 +32,9 @@ supabase functions deploy telegram-bot --project-ref <PROJECT_REF>
 2. Set the Telegram webhook with the secret token:
 
 ```bash
-curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook?url=https://<PROJECT_REF>.functions.supabase.co/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET"
+curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -d "url=https://<PROJECT_REF>.functions.supabase.co/telegram-bot" \
+  -d "secret_token=$TELEGRAM_WEBHOOK_SECRET"
 ```
 
 ## Troubleshooting
@@ -44,11 +47,13 @@ curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook?url=https://<PR
 ```bash
 supabase secrets set TELEGRAM_BOT_TOKEN=<new token>
 ```
+
 3. Confirm the value:
 
 ```bash
 supabase secrets get TELEGRAM_BOT_TOKEN
 ```
+
 4. Redeploy the function so it picks up the new token (see below).
 
 ### Redeploying Edge Functions
@@ -59,4 +64,5 @@ If updates or new secrets are not reflected, redeploy:
 supabase functions deploy telegram-bot --project-ref <PROJECT_REF>
 ```
 
-Ensure the webhook still points to the current deployment and rerun tests after redeploying.
+Ensure the webhook still points to the current deployment and rerun tests after
+redeploying.

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -17,8 +17,10 @@ supabase start
 supabase functions serve telegram-bot --no-verify-jwt
 
 # Ping (expects 200)
-  curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
-    -H "content-type: application/json" -d '{"test":"ping"}'
+  curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot" \
+    -H "content-type: application/json" \
+    -H "X-Telegram-Bot-Api-Secret-Token: $TELEGRAM_WEBHOOK_SECRET" \
+    -d '{"test":"ping"}'
 ```
 
 ### Mini App launch options
@@ -42,8 +44,10 @@ Pay","web_app":{"short_name":"dynamic_pay"}}}'
 # Delete existing webhook
 curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/deleteWebhook"
 
-# Set webhook with secret gate (replace <PROJECT_REF>)
-curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook?url=https://<PROJECT_REF>.functions.supabase.co/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET"
+# Set webhook with secret token (replace <PROJECT_REF>)
+curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+  -d "url=https://<PROJECT_REF>.functions.supabase.co/telegram-bot" \
+  -d "secret_token=$TELEGRAM_WEBHOOK_SECRET"
 
 # Inspect current webhook
 curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getWebhookInfo"

--- a/docs/RUNBOOK_start-not-responding.md
+++ b/docs/RUNBOOK_start-not-responding.md
@@ -2,7 +2,7 @@
 
 ## Quick checks
 
-1) Webhook status:
+1. Webhook status:
 
 ```
 deno run -A scripts/check-webhook.ts
@@ -11,7 +11,7 @@ deno run -A scripts/check-webhook.ts
 - If URL is empty or wrong, re-set webhook (per GO_LIVE_CHECKLIST).
 - If last_error_message exists, fix that upstream (SSL, 4xx/5xx, timeouts).
 
-2) Ping your deployed function with a synthetic `/start`:
+2. Ping your deployed function with a synthetic `/start`:
 
 ```
 export TELEGRAM_WEBHOOK_SECRET=... # prod secret
@@ -23,7 +23,7 @@ deno run -A scripts/ping-webhook.ts
 
 - Expect 2xx. Non-2xx → check logs on Supabase Edge.
 
-3) Offline smoke test (no secrets needed):
+3. Offline smoke test (no secrets needed):
 
 ```
 deno test -A functions/_tests/start-command.test.ts
@@ -32,20 +32,22 @@ deno test -A functions/_tests/start-command.test.ts
 - If import fails, update the path inside the test.
 - If call fails, inspect thrown errors for missing env or bad parsing.
 
-4) Confirm the bot token is present:
+4. Confirm the bot token is present:
 
 ```
 supabase secrets get TELEGRAM_BOT_TOKEN
 ```
 
-- An empty value means the Edge function cannot reply to messages. Set it with `supabase secrets set TELEGRAM_BOT_TOKEN=...`.
+- An empty value means the Edge function cannot reply to messages. Set it with
+  `supabase secrets set TELEGRAM_BOT_TOKEN=...`.
 
 ## Common causes
 
-- Wrong webhook secret header or missing header (some handlers validate `X-Telegram-Bot-Api-Secret-Token`; others use `?secret=`).
+- Wrong or missing `X-Telegram-Bot-Api-Secret-Token` header.
 - Webhook URL not set or points to old branch/deployment.
 - Handler expecting `message.entities[type=bot_command]` but update lacks it.
-- Mini-app branch: `/start` may shortcut to a menu button if `MINI_APP_URL`/`MINI_APP_SHORT_NAME` not configured.
+- Mini-app branch: `/start` may shortcut to a menu button if
+  `MINI_APP_URL`/`MINI_APP_SHORT_NAME` not configured.
 - Missing `TELEGRAM_BOT_TOKEN` (bot cannot send responses).
 
 ## When it’s fixed

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -98,8 +98,8 @@ crash).
 
 ## 6) Telegram Webhook Behavior
 
-- **Secret check:** `?secret=` must match `TELEGRAM_WEBHOOK_SECRET`; on mismatch
-  respond **200** (skip processing).
+- **Secret check:** header `X-Telegram-Bot-Api-Secret-Token` must match
+  `TELEGRAM_WEBHOOK_SECRET`; on mismatch respond **200** (skip processing).
 - **Ping path:** if body is `{"test":"ping"}`, return `{"pong":true}` 200.
 - **OCR guard:** if no image/document, skip OCR and return 200.
 - **Errors:** Wrap handler in try/catch; log, then return 200 `{ ok: true }`.
@@ -144,11 +144,11 @@ crash).
 
 - **Local:**\
   `supabase start` → `supabase functions serve telegram-bot --no-verify-jwt` →\
-  `curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" -H "content-type: application/json" -d '{"test":"ping"}'`
+  `curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot" -H "content-type: application/json" -H "X-Telegram-Bot-Api-Secret-Token: $TELEGRAM_WEBHOOK_SECRET" -d '{"test":"ping"}'`
 - **Typecheck:**
   `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`
-- **Post-deploy smoke:** invoke ping; check `getWebhookInfo` has `?secret=` and
-  low pending updates.
+- **Post-deploy smoke:** invoke ping; check `getWebhookInfo` shows the correct
+  URL and low pending updates.
 
 ---
 

--- a/functions/_tests/start-command.test.ts
+++ b/functions/_tests/start-command.test.ts
@@ -65,7 +65,7 @@ Deno.test("handler responds to /start offline", async () => {
       entities: [{ offset: 0, length: 6, type: "bot_command" }],
     },
   };
-  const req = new Request("http://local/telegram-bot?secret=test-secret", {
+  const req = new Request("http://local/telegram-bot", {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/scripts/ping-webhook.ts
+++ b/scripts/ping-webhook.ts
@@ -2,7 +2,6 @@
 /**
  * Sends a synthetic /start update to your deployed Edge function.
  * - Adds X-Telegram-Bot-Api-Secret-Token header (your webhook secret)
- * - Also appends ?secret=... to URL for handlers that expect query validation
  * - Body matches Telegram update shape for a /start command.
  *
  * Env:
@@ -21,16 +20,15 @@ if (!secret) {
 const explicitUrl = Deno.env.get("TELEGRAM_WEBHOOK_URL");
 const proj = Deno.env.get("SUPABASE_PROJECT_ID");
 
-const baseUrl =
-  explicitUrl ?? (proj ? `https://${proj}.functions.supabase.co/telegram-bot` : null);
+const baseUrl = explicitUrl ??
+  (proj ? `https://${proj}.functions.supabase.co/telegram-bot` : null);
 
 if (!baseUrl) {
   console.error("Provide TELEGRAM_WEBHOOK_URL or SUPABASE_PROJECT_ID");
   Deno.exit(1);
 }
 
-// Ensure the secret is also present as a query param for maximum compatibility
-const url = baseUrl.includes("?") ? `${baseUrl}&secret=${encodeURIComponent(secret)}` : `${baseUrl}?secret=${encodeURIComponent(secret)}`;
+const url = baseUrl;
 
 const update = {
   update_id: 999999,

--- a/scripts/set-webhook.ts
+++ b/scripts/set-webhook.ts
@@ -3,9 +3,7 @@
  * Registers/updates the Telegram webhook with a secret and clears pending updates.
  *
  * Notes:
- * - Your current handler validates a `?secret=` query parameter. To be compatible,
- *   this script appends `?secret=...` to the webhook URL automatically.
- * - Telegram will also send the secret in header X-Telegram-Bot-Api-Secret-Token.
+ * - Telegram sends the secret in header `X-Telegram-Bot-Api-Secret-Token`.
  *
  * Env (required):
  *   TELEGRAM_BOT_TOKEN
@@ -32,13 +30,8 @@ if (!secret) {
   Deno.exit(1);
 }
 
-// Ensure the URL also carries the secret as a query parameter for handler compatibility
-const urlWithSecret = baseUrl.includes("?")
-  ? `${baseUrl}&secret=${encodeURIComponent(secret)}`
-  : `${baseUrl}?secret=${encodeURIComponent(secret)}`;
-
 const params = new URLSearchParams();
-params.set("url", urlWithSecret);
+params.set("url", baseUrl);
 params.set("secret_token", secret);
 params.set("drop_pending_updates", "true");
 
@@ -49,10 +42,15 @@ const setRes = await fetch(`https://api.telegram.org/bot${token}/setWebhook`, {
 });
 const setJson = await setRes.json();
 console.log("setWebhook status:", setRes.status);
-console.log("setWebhook response:", JSON.stringify({ ok: setJson.ok, description: setJson.description }, null, 2));
+console.log(
+  "setWebhook response:",
+  JSON.stringify({ ok: setJson.ok, description: setJson.description }, null, 2),
+);
 
 // Follow-up: show getWebhookInfo summary
-const infoRes = await fetch(`https://api.telegram.org/bot${token}/getWebhookInfo`);
+const infoRes = await fetch(
+  `https://api.telegram.org/bot${token}/getWebhookInfo`,
+);
 const infoJson = await infoRes.json();
 if (infoJson.ok) {
   const i = infoJson.result ?? {};
@@ -60,7 +58,9 @@ if (infoJson.ok) {
   console.log("Has custom cert:", !!i.has_custom_certificate);
   console.log("Pending updates:", i.pending_update_count ?? 0);
   if (i.last_error_message) {
-    const ts = i.last_error_date ? new Date(i.last_error_date * 1000).toISOString() : "";
+    const ts = i.last_error_date
+      ? new Date(i.last_error_date * 1000).toISOString()
+      : "";
     console.log("Last error:", i.last_error_message, ts ? `@ ${ts}` : "");
   }
 } else {

--- a/scripts/telegram-webhook.sh
+++ b/scripts/telegram-webhook.sh
@@ -7,7 +7,7 @@ Usage: scripts/telegram-webhook.sh [delete|set|info]
 
 Environment variables required:
   TELEGRAM_BOT_TOKEN          # BotFather token
-  TELEGRAM_WEBHOOK_SECRET     # Secret query param appended to webhook URL (only for 'set')
+  TELEGRAM_WEBHOOK_SECRET     # Secret token for X-Telegram-Bot-Api-Secret-Token (only for 'set')
 
 Optional (one of):
   PROJECT_REF                 # Supabase project ref (e.g. qeejuomcapbdlhnjqjcc)
@@ -52,7 +52,7 @@ case "$cmd" in
     echo "[+] Setting webhook (URL hidden)..."
     # Do not echo the full URL to avoid leaking secrets
     curl -sS -X POST "${API_BASE}/setWebhook" \
-      -d "url=${FUNCTION_URL}?secret=${TELEGRAM_WEBHOOK_SECRET}" \
+      -d "url=${FUNCTION_URL}" \
       -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" | jq -r '.description // "ok"'
     ;;
   info)

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -53,8 +53,7 @@ serve(async (req) => {
     console.log("Cleared pending updates:", clearUpdatesResult);
 
     // 3. Re-establish the webhook
-    const webhookUrl =
-      `${supabaseUrl}/functions/v1/telegram-bot?secret=${secret}`;
+    const webhookUrl = `${supabaseUrl}/functions/v1/telegram-bot`;
     const setWebhookResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/setWebhook`,
       {

--- a/supabase/functions/setup-telegram-webhook/index.ts
+++ b/supabase/functions/setup-telegram-webhook/index.ts
@@ -52,9 +52,8 @@ serve(async (req) => {
       });
     }
 
-    // Set webhook URL to our edge function (includes ?secret= for compatibility)
-    const webhookUrl =
-      `${SUPABASE_URL}/functions/v1/telegram-bot?secret=${SECRET}`;
+    // Set webhook URL to our edge function (secret sent via header)
+    const webhookUrl = `${SUPABASE_URL}/functions/v1/telegram-bot`;
 
     console.log("🔗 Setting webhook...");
 

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -37,8 +37,7 @@ serve(async (req) => {
     }
 
     // Get the webhook URL for our telegram-bot function
-    const webhookUrl =
-      `${supabaseUrl}/functions/v1/telegram-bot?secret=${secret}`;
+    const webhookUrl = `${supabaseUrl}/functions/v1/telegram-bot`;
 
     logger.info("Webhook URL prepared");
 


### PR DESCRIPTION
## Summary
- remove legacy `?secret=` query parameter from webhook URLs
- send `TELEGRAM_WEBHOOK_SECRET` only via `X-Telegram-Bot-Api-Secret-Token` header
- update scripts, tests and docs to reflect the standardized approach

## Testing
- ⚠️ `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts` (invalid peer certificate for registry.npmjs.org)
- ⚠️ `deno test -A` (invalid peer certificate for registry.npmjs.org)


------
https://chatgpt.com/codex/tasks/task_e_689ca3e744f88322b4dd46839f09dcfe