### PR TITLE
Prevent static file path traversal

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -46,7 +46,9 @@ function mime(p: string) {
 
 async function readFileFrom(rootDir: URL, relPath: string): Promise<Response | null> {
   try {
-    const url = new URL(`./${relPath.replace(/^\/+/, "")}`, rootDir);
+    const rel = relPath.replace(/^\/+/, "");
+    const url = new URL(`./${rel}`, rootDir);
+    if (!url.pathname.startsWith(rootDir.pathname)) return null; // prevent path traversal
     const data = await Deno.readFile(url);
     const h = new Headers({
       "content-type": mime(relPath),


### PR DESCRIPTION
## Summary
- Sanitize relative paths in `readFileFrom` and reject requests that escape the configured root directory
- Guard against directory traversal when serving static files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbeb34f588322b9432a3491dbb7f2