### PR TITLE
refactor: simplify HEAD root detection

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -67,9 +67,8 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
 
   // HEAD allowed on roots
   if (req.method === "HEAD") {
-    if (path === "" || path === "/" || path === "/miniapp" || path === "/miniapp/") {
-      return new Response(null, { status: 200 });
-    }
+    const roots = new Set(["", "/miniapp"]);
+    if (roots.has(path)) return new Response(null, { status: 200 });
     return new Response(null, { status: 404 });
   }
 


### PR DESCRIPTION
## Summary
- simplify HEAD request handling in serveStatic by using a canonical root list
- drop unreachable comparisons when checking for allowed paths

## Testing
- `npm test` (fails: Segmentation fault)


------
https://chatgpt.com/codex/tasks/task_e_689cbeb4715483229edfb3479921a1db