### PR TITLE
Use Response body for SPA index

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -97,7 +97,7 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
       const h = new Headers(idx.headers);
       h.set("x-frame-options", "ALLOWALL"); // Telegram WebView
       for (const [k, v] of Object.entries(sec)) h.set(k, v);
-      return new Response(await idx.arrayBuffer(), { headers: h, status: idx.status });
+      return new Response(idx.body, { headers: h, status: idx.status });
     }
     return nf("index.html missing");
   }


### PR DESCRIPTION
## Summary
- Return `idx.body` directly when serving SPA index to avoid extra array buffer copy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbeb601c483229d38d25995309364