### PR TITLE
refactor: reuse shared security header config

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -7,8 +7,7 @@ export type StaticOpts = {
   security?: Record<string, string>;
   extraFiles?: string[]; // e.g., ["/favicon.svg", "/site.webmanifest"]
 };
-
-const DEFAULT_SECURITY = {
+export const DEFAULT_SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-content-type-options": "nosniff",
   "permissions-policy": "geolocation=(), microphone=(), camera=()",

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,22 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { serveStatic } from "../_shared/static.ts";
+import { serveStatic, DEFAULT_SECURITY } from "../_shared/static.ts";
 import { mna } from "../_shared/http.ts";
 
 const ROOT = new URL("./static/", import.meta.url);
 
-const SECURITY = {
-  "referrer-policy": "strict-origin-when-cross-origin",
-  "x-content-type-options": "nosniff",
-  "permissions-policy": "geolocation=(), microphone=(), camera=()",
-  "content-security-policy":
-    "default-src 'self' https://*.telegram.org https://telegram.org; " +
-    "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
-    "style-src 'self' 'unsafe-inline'; " +
-    "img-src 'self' data: https:; " +
-    "connect-src 'self' https://*.functions.supabase.co https://*.supabase.co wss://*.supabase.co; " +
-    "font-src 'self' data:; " +
-    "frame-ancestors *;",
-} as const;
 
 let INDEX_HTML = "";
 try {
@@ -42,7 +29,7 @@ function serveIndex(): Response {
     "cache-control": "no-cache",
     "x-frame-options": "ALLOWALL",
   });
-  for (const [k, v] of Object.entries(SECURITY)) h.set(k, v as string);
+  for (const [k, v] of Object.entries(DEFAULT_SECURITY)) h.set(k, v as string);
   return new Response(INDEX_HTML, { headers: h });
 }
 


### PR DESCRIPTION
## Summary
- export `DEFAULT_SECURITY` headers from shared static module
- reuse shared security configuration in miniapp

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbeb6c2cc832283d700b0f6d7b762