### PR TITLE
feat(telegram-bot): allow readonly env key arrays

### DIFF
--- a/supabase/functions/telegram-bot/helpers/require-env.ts
+++ b/supabase/functions/telegram-bot/helpers/require-env.ts
@@ -1,6 +1,8 @@
 import { EnvKey, optionalEnv } from "../../_shared/env.ts";
 
-export function requireEnv(keys: string[]): { ok: boolean; missing: string[] } {
+export function requireEnv(
+  keys: readonly string[],
+): { ok: boolean; missing: string[] } {
   const missing = keys.filter((k) => !optionalEnv(k as EnvKey));
   return { ok: missing.length === 0, missing };
 }

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -557,9 +557,7 @@ export async function serveWebhook(req: Request): Promise<Response> {
   if (authResp) return authResp;
 
   try {
-    const { ok: envOk, missing } = requireEnvCheck(
-      REQUIRED_ENV_KEYS as unknown as string[],
-    );
+    const { ok: envOk, missing } = requireEnvCheck(REQUIRED_ENV_KEYS);
     if (!envOk) {
       console.error("Missing env vars", missing);
       return oops("Missing env vars", missing);


### PR DESCRIPTION
## Summary
- allow requireEnv helper to accept readonly string arrays
- clean up index.ts call by removing unnecessary cast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc078810883229957a8f743c5768d