### PR TITLE
feat: document fire-and-forget receipt pipeline

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -617,7 +617,10 @@ export async function serveWebhook(req: Request): Promise<Response> {
     await handleCallback(update);
 
     const fileId = getFileIdFromUpdate(update);
-    if (fileId) startReceiptPipeline(update);
+    if (fileId) {
+      // Fire-and-forget: run receipt processing without delaying the response
+      void startReceiptPipeline(update);
+    }
 
     return ok({ handled: true });
   } catch (e) {


### PR DESCRIPTION
## Summary
- clarify receipt pipeline execution with explicit `void` and comment

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cc078d0f8832299de74c35c1e352d