### PR TITLE
feat: ensure webhook secret exists

### DIFF
--- a/supabase/functions/_shared/telegram_secret.ts
+++ b/supabase/functions/_shared/telegram_secret.ts
@@ -8,6 +8,10 @@ interface SupabaseLike {
         limit: (n: number) => { maybeSingle: () => Promise<{ data?: { setting_value?: unknown } }> };
       };
     };
+    upsert: (
+      values: Record<string, unknown>,
+      options: { onConflict: string },
+    ) => Promise<{ error?: { message: string } }>;
   };
 }
 
@@ -45,6 +49,28 @@ export async function expectedSecret(
   supa?: SupabaseLike,
 ): Promise<string | null> {
   return (await readDbWebhookSecret(supa)) || maybe("TELEGRAM_WEBHOOK_SECRET");
+}
+
+function genHex(n = 24) {
+  const buf = new Uint8Array(n);
+  crypto.getRandomValues(buf);
+  return Array.from(buf).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function ensureWebhookSecret(
+  supa: SupabaseLike,
+  envSecret?: string | null,
+): Promise<string> {
+  const existing = await readDbWebhookSecret(supa);
+  if (existing) return existing;
+  const secret = envSecret ?? maybe("TELEGRAM_WEBHOOK_SECRET") ?? genHex(24);
+  const { error } = await supa.from("bot_settings").upsert({
+    setting_key: "TELEGRAM_WEBHOOK_SECRET",
+    setting_value: secret,
+    is_active: true,
+  }, { onConflict: "setting_key" });
+  if (error) throw new Error("upsert bot_settings failed: " + error.message);
+  return secret;
 }
 export async function validateTelegramHeader(
   req: Request,


### PR DESCRIPTION
## Summary
- add ensureWebhookSecret helper to fetch, generate and store Telegram webhook secret
- refactor webhook setup utilities to use centralized secret helper
- test secret resolution for DB, env and generated cases

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in BotDiagnostics.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689d548488bc8322988eb2ace23d9c8e