### PR TITLE
feat: enforce frame restrictions

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -11,6 +11,7 @@ export const DEFAULT_SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-content-type-options": "nosniff",
   "permissions-policy": "geolocation=(), microphone=(), camera=()",
+  "x-frame-options": "SAMEORIGIN",
   "content-security-policy":
     "default-src 'self' https://*.telegram.org https://telegram.org; " +
     "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
@@ -103,7 +104,6 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
     const idx = await readFileFrom(opts.rootDir, "index.html");
     if (idx) {
       const h = new Headers(idx.headers);
-      h.set("x-frame-options", "ALLOWALL"); // Telegram WebView
       for (const [k, v] of Object.entries(sec)) h.set(k, v);
       return new Response(idx.body, { headers: h, status: idx.status });
     }


### PR DESCRIPTION
## Summary
- add x-frame-options to default security headers
- drop SPA-specific override so all static responses share security headers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6aed5ae88322bcdd10a3eb815ff6