### PR TITLE
refactor: simplify HEAD request path check

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -80,7 +80,7 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
 
   // HEAD allowed on roots
   if (req.method === "HEAD") {
-    if (path === "" || path === "/" || path === "/miniapp" || path === "/miniapp/") {
+    if (path === "" || path === "/miniapp") {
       return setSec(new Response(null, { status: 200 }));
     }
     return setSec(new Response(null, { status: 404 }));


### PR DESCRIPTION
## Summary
- Simplify static HEAD request logic to rely on a trailing-slash-free path
- Drop redundant `"/miniapp/"` comparison for cleaner routing

## Testing
- `~/.deno/bin/deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check`
- `~/.deno/bin/deno fmt --check supabase/functions/_shared/static.ts` *(fails: Found 1 not formatted file in 1 file)*

------
https://chatgpt.com/codex/tasks/task_e_689d6aea00888322ad1138a0895c0473