### PR TITLE
test: add webhook endpoint integration tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,20 @@
+# Tests
+
+Integration tests cover live webhook endpoints using mock external services.
+
+## Required Environment Variables
+
+The tests set placeholder values for required secrets, but the following
+variables may be overridden when running the suite:
+
+| Variable | Purpose |
+| --- | --- |
+| `SUPABASE_URL` | Base URL for the mocked Supabase client |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for database access |
+| `BINANCE_SECRET_KEY` | Secret used to verify Binance Pay signatures |
+| `TELEGRAM_BOT_TOKEN` | Token for sending Telegram messages |
+| `TELEGRAM_WEBHOOK_SECRET` | Secret header expected by the Telegram webhook |
+| `MINI_APP_URL` | Optional base URL returned in `/start` responses |
+
+These values are populated with dummy data inside the tests themselves, so no
+real credentials are required to run `npm test`.

--- a/tests/binance-pay-webhook.live.test.ts
+++ b/tests/binance-pay-webhook.live.test.ts
@@ -1,0 +1,172 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+// compute HMAC SHA-512 signature for Binance headers
+async function sign(secret: string, timestamp: string, nonce: string, body: string) {
+  const payload = `${timestamp}\n${nonce}\n${body}\n`;
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-512" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload));
+  return Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, "0")).join("").toUpperCase();
+}
+
+function mockTelegram() {
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  return { calls, restore: () => (globalThis.fetch = originalFetch) };
+}
+
+denoEnvCleanup();
+
+denoTest("binance webhook completes payment and updates DB", async () => {
+  setEnv();
+  const { calls, restore } = mockTelegram();
+  try {
+    const payments = [{
+      id: "p1",
+      user_id: 100,
+      plan_id: "plan1",
+      status: "pending",
+      subscription_plans: { is_lifetime: false, duration_months: 1, name: "Basic" },
+    }];
+    const bot_users = [{
+      id: "u1",
+      telegram_id: 100,
+      is_vip: false,
+      current_plan_id: null,
+      subscription_expires_at: null,
+    }];
+    (globalThis as any).__SUPA_MOCK__ = {
+      tables: { payments, bot_users, user_subscriptions: [], admin_logs: [], plan_channels: [], channel_memberships: [] },
+    };
+    const mod = await import("../supabase/functions/binance-pay-webhook/index.ts");
+    const body = await Deno.readTextFile(new URL("./fixtures/binance-pay-success.json", import.meta.url));
+    const ts = "1";
+    const nonce = "abc";
+    const sig = await sign("shhh", ts, nonce, body);
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "BinancePay-Timestamp": ts,
+        "BinancePay-Nonce": nonce,
+        "BinancePay-Signature": sig,
+      },
+      body,
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(payments[0].status, "completed");
+    assertEquals(bot_users[0].is_vip, true);
+    assertEquals(calls.length > 0, true);
+  } finally {
+    restore();
+    cleanup();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+});
+
+denoTest("binance webhook rejects invalid signature", async () => {
+  setEnv();
+  const { restore } = mockTelegram();
+  try {
+    const payments = [{
+      id: "p1",
+      user_id: 100,
+      plan_id: "plan1",
+      status: "pending",
+      subscription_plans: { is_lifetime: false, duration_months: 1, name: "Basic" },
+    }];
+    const bot_users = [{ id: "u1", telegram_id: 100, is_vip: false, current_plan_id: null, subscription_expires_at: null }];
+    (globalThis as any).__SUPA_MOCK__ = {
+      tables: { payments, bot_users, user_subscriptions: [], admin_logs: [], plan_channels: [], channel_memberships: [] },
+    };
+    const mod = await import("../supabase/functions/binance-pay-webhook/index.ts");
+    const body = await Deno.readTextFile(new URL("./fixtures/binance-pay-success.json", import.meta.url));
+    const ts = "1";
+    const nonce = "abc";
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "BinancePay-Timestamp": ts,
+        "BinancePay-Nonce": nonce,
+        "BinancePay-Signature": "WRONG",
+      },
+      body,
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 403);
+    assertEquals(payments[0].status, "pending");
+    assertEquals(bot_users[0].is_vip, false);
+  } finally {
+    restore();
+    cleanup();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+});
+
+denoTest("binance webhook errors when payment missing", async () => {
+  setEnv();
+  const { restore } = mockTelegram();
+  try {
+    const payments: any[] = [];
+    const bot_users: any[] = [];
+    (globalThis as any).__SUPA_MOCK__ = {
+      tables: { payments, bot_users, user_subscriptions: [], admin_logs: [], plan_channels: [], channel_memberships: [] },
+    };
+    const mod = await import("../supabase/functions/binance-pay-webhook/index.ts");
+    const body = await Deno.readTextFile(new URL("./fixtures/binance-pay-success.json", import.meta.url));
+    const ts = "1";
+    const nonce = "abc";
+    const sig = await sign("shhh", ts, nonce, body);
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "BinancePay-Timestamp": ts,
+        "BinancePay-Nonce": nonce,
+        "BinancePay-Signature": sig,
+      },
+      body,
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 500);
+  } finally {
+    restore();
+    cleanup();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+});
+
+function setEnv() {
+  Deno.env.set("SUPABASE_URL", "https://supabase.test");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  Deno.env.set("BINANCE_SECRET_KEY", "shhh");
+}
+
+function cleanup() {
+  Deno.env.delete("SUPABASE_URL");
+  Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+  Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  Deno.env.delete("BINANCE_SECRET_KEY");
+  delete (globalThis as any).__SUPA_MOCK__;
+}
+
+function denoEnvCleanup() {
+  cleanup();
+}
+
+function denoTest(name: string, fn: () => Promise<void>) {
+  Deno.test(name, fn);
+}

--- a/tests/fixtures/binance-pay-success.json
+++ b/tests/fixtures/binance-pay-success.json
@@ -1,0 +1,9 @@
+{
+  "bizType": "PAY_SUCCESS",
+  "data": {
+    "merchantTradeNo": "p1",
+    "transactionId": "tx123",
+    "payerInfo": {},
+    "transactionTime": "0"
+  }
+}

--- a/tests/fixtures/telegram-start.json
+++ b/tests/fixtures/telegram-start.json
@@ -1,0 +1,6 @@
+{
+  "message": {
+    "text": "/start deep",
+    "chat": { "id": 1 }
+  }
+}

--- a/tests/telegram-webhook.live.test.ts
+++ b/tests/telegram-webhook.live.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+function mockTelegram() {
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  return { calls, restore: () => (globalThis.fetch = originalFetch) };
+}
+
+denoEnvCleanup();
+
+denoTest("telegram webhook responds to /start", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("MINI_APP_URL", "https://example.com/app");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  const { calls, restore } = mockTelegram();
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const body = await Deno.readTextFile(new URL("./fixtures/telegram-start.json", import.meta.url));
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
+      body,
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(calls.length, 1);
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.chat_id, 1);
+  } finally {
+    restore();
+    cleanup();
+  }
+});
+
+denoTest("telegram webhook rejects bad secret", async () => {
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "correct");
+  const { calls, restore } = mockTelegram();
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const body = await Deno.readTextFile(new URL("./fixtures/telegram-start.json", import.meta.url));
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "wrong",
+      },
+      body,
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 401);
+    assertEquals(calls.length, 0);
+  } finally {
+    restore();
+    cleanup();
+  }
+});
+
+denoTest("telegram webhook handles malformed JSON", async () => {
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  const { restore } = mockTelegram();
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": "testsecret",
+      },
+      body: "{ bad",
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 400);
+  } finally {
+    restore();
+    cleanup();
+  }
+});
+
+function cleanup() {
+  Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  Deno.env.delete("MINI_APP_URL");
+  Deno.env.delete("TELEGRAM_WEBHOOK_SECRET");
+}
+
+function denoEnvCleanup() {
+  cleanup();
+}
+
+function denoTest(name: string, fn: () => Promise<void>) {
+  Deno.test(name, fn);
+}


### PR DESCRIPTION
## Summary
- add e2e tests for binance-pay-webhook with mock Telegram and Supabase
- add e2e tests for telegram-webhook covering secret validation and bad JSON
- document environment variables for running webhook tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6e826eb88322ae87df70fe732395