### PR TITLE
refactor: centralize Supabase client setup

### DIFF
--- a/supabase/functions/_shared/client.ts
+++ b/supabase/functions/_shared/client.ts
@@ -1,0 +1,13 @@
+import { createClient as createSupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getEnv } from "./env.ts";
+
+const url = getEnv("SUPABASE_URL");
+const anonKey = getEnv("SUPABASE_ANON_KEY");
+const serviceKey = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+const options = { auth: { persistSession: false } };
+
+export function createClient(key: "anon" | "service" = "service") {
+  const k = key === "service" ? serviceKey : anonKey;
+  return createSupabaseClient(url, k, options);
+}

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { ok, bad, nf, mna, unauth } from "../_shared/http.ts";
 import { requireEnv } from "../_shared/env.ts";
@@ -20,9 +20,9 @@ export async function handler(req: Request): Promise<Response> {
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return unauth();
 
-  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc, TELEGRAM_BOT_TOKEN: bot } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TELEGRAM_BOT_TOKEN"] as const);
-  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const { TELEGRAM_BOT_TOKEN: bot } =
+    requireEnv(["TELEGRAM_BOT_TOKEN"] as const);
+  const supa = createClient();
 
   // Load payment + user + plan
   const { data: p } = await supa.from("payments").select("id,status,user_id,plan_id,amount,currency,created_at").eq("id", body.payment_id).maybeSingle();

--- a/supabase/functions/admin-bans/index.ts
+++ b/supabase/functions/admin-bans/index.ts
@@ -1,7 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { isAdmin, verifyInitDataAndGetUser } from "../_shared/telegram.ts";
-import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") {
@@ -25,13 +24,7 @@ serve(async (req) => {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
-  const supa = createClient(
-    SUPABASE_URL,
-    SUPABASE_SERVICE_ROLE_KEY,
-    { auth: { persistSession: false } },
-  );
+  const supa = createClient();
 
   if (body.op === "list") {
     const { data } = await supa.from("abuse_bans").select(

--- a/supabase/functions/admin-list-pending/index.ts
+++ b/supabase/functions/admin-list-pending/index.ts
@@ -1,15 +1,12 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
   let body: { initData?: string; limit?: number; offset?: number }; try { body = await req.json(); } catch { return new Response("Bad JSON", { status: 400 }); }
 
-  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: srv } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });

--- a/supabase/functions/admin-logs/index.ts
+++ b/supabase/functions/admin-logs/index.ts
@@ -1,7 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
-import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
@@ -10,9 +9,7 @@ serve(async (req) => {
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return new Response("Unauthorized", { status: 401 });
 
-  const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
-  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const limit = Math.min(Math.max(body.limit ?? 20, 1), 100);
   const offset = Math.max(body.offset ?? 0, 0);

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { getEnv, optionalEnv } from "../_shared/env.ts";
 import { ok } from "../_shared/http.ts";
 
@@ -55,9 +55,7 @@ serve(async (req) => {
     return new Response("Admin not allowed", { status: 403 });
   }
 
-  const url = getEnv("SUPABASE_URL");
-  const svc = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const supa = createClient();
   const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
   const { data: p, error: perr } = await supa

--- a/supabase/functions/analytics-collector/index.ts
+++ b/supabase/functions/analytics-collector/index.ts
@@ -1,13 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { ok } from "../_shared/http.ts";
-import { getEnv } from "../_shared/env.ts";
 
-function svc() {
-  const url = getEnv("SUPABASE_URL");
-  const key = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  return createClient(url, key, { auth: { persistSession: false } });
-}
 function isoDay(d: Date) {
   return d.toISOString().slice(0, 10);
 }
@@ -18,7 +12,7 @@ serve(async (req) => {
     return ok({ name: "analytics-collector", ts: new Date().toISOString() });
   }
   if (req.method === "HEAD") return new Response(null, { status: 200 });
-  const supa = svc();
+  const supa = createClient();
 
   // Define "day" as UTC day for simplicity; adjust if you prefer MVT (UTC+5).
   const today = new Date();

--- a/supabase/functions/analytics-data/index.ts
+++ b/supabase/functions/analytics-data/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
-import { requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -21,17 +20,7 @@ serve(async (req) => {
   try {
     logStep("Analytics data request started");
 
-    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-      [
-        "SUPABASE_URL",
-        "SUPABASE_SERVICE_ROLE_KEY",
-      ] as const,
-    );
-    const supabaseClient = createClient(
-      SUPABASE_URL,
-      SUPABASE_SERVICE_ROLE_KEY,
-      { auth: { persistSession: false } },
-    );
+    const supabaseClient = createClient();
 
     const { timeframe } = await req.json().catch(() => ({
       timeframe: "today",

--- a/supabase/functions/binance-pay-checkout/index.ts
+++ b/supabase/functions/binance-pay-checkout/index.ts
@@ -1,6 +1,6 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
+import { createClient } from "../_shared/client.ts";
 import { optionalEnv, requireEnv } from "../_shared/env.ts";
 import { createLogger } from "../_shared/logger.ts";
 
@@ -14,16 +14,10 @@ const corsHeaders = {
 const {
   BINANCE_API_KEY: _BINANCE_PAY_API_KEY,
   BINANCE_SECRET_KEY: _BINANCE_PAY_SECRET_KEY,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} = requireEnv(
-  [
-    "BINANCE_API_KEY",
-    "BINANCE_SECRET_KEY",
-    "SUPABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
-  ] as const,
-);
+} = requireEnv([
+  "BINANCE_API_KEY",
+  "BINANCE_SECRET_KEY",
+] as const);
 const _BINANCE_PAY_MERCHANT_ID = "59586072";
 const _BINANCE_PAY_BASE_URL = "https://bpay.binanceapi.com";
 
@@ -115,7 +109,7 @@ serve(async (req) => {
     }
 
     // Initialize Supabase client
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const supabase = createClient();
     logger.info("Supabase client initialized");
 
     // Get plan details

--- a/supabase/functions/binance-pay-webhook/index.ts
+++ b/supabase/functions/binance-pay-webhook/index.ts
@@ -1,7 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
-import { optionalEnv, requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
+import { optionalEnv } from "../_shared/env.ts";
 import { createLogger } from "../_shared/logger.ts";
 
 const corsHeaders = {
@@ -89,13 +89,7 @@ export async function handler(req: Request): Promise<Response> {
     logger.info("Binance Pay webhook received:", webhookData);
 
     // Initialize Supabase client
-    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-      [
-        "SUPABASE_URL",
-        "SUPABASE_SERVICE_ROLE_KEY",
-      ] as const,
-    );
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const supabase = createClient();
 
     const { bizType, data } = webhookData;
 

--- a/supabase/functions/binancepay-webhook/index.ts
+++ b/supabase/functions/binancepay-webhook/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") {
@@ -17,13 +16,7 @@ serve(async (req) => {
   // Example: locate payment by payment_provider_id from your checkout-init step
   const providerId = body?.merchantTradeNo || body?.prepayId || null;
 
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
-  const supa = createClient(
-    SUPABASE_URL,
-    SUPABASE_SERVICE_ROLE_KEY,
-    { auth: { persistSession: false } },
-  );
+  const supa = createClient();
 
   if (providerId) {
     const { data: rows } = await supa.from("payments").select("id").eq(

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 type Body = {
   telegram_id: string;
@@ -31,9 +30,7 @@ serve(async (req) => {
     return new Response("Bad JSON", { status: 400 });
   }
 
-  const url = getEnv("SUPABASE_URL");
-  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const { data: bu } = await supa
     .from("bot_users")

--- a/supabase/functions/cleanup-old-receipts/index.ts
+++ b/supabase/functions/cleanup-old-receipts/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
-import { requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -23,17 +22,7 @@ serve(async (req) => {
   try {
     logStep("Cleanup job started");
 
-    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-      [
-        "SUPABASE_URL",
-        "SUPABASE_SERVICE_ROLE_KEY",
-      ] as const,
-    );
-    const supabaseClient = createClient(
-      SUPABASE_URL,
-      SUPABASE_SERVICE_ROLE_KEY,
-      { auth: { persistSession: false } },
-    );
+    const supabaseClient = createClient();
 
     // Calculate date 30 days ago
     const thirtyDaysAgo = new Date();

--- a/supabase/functions/cleanup-old-sessions/index.ts
+++ b/supabase/functions/cleanup-old-sessions/index.ts
@@ -1,22 +1,12 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
+import { createClient } from "../_shared/client.ts";
 import { requireEnv } from "../_shared/env.ts";
 
-const {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-  TELEGRAM_BOT_TOKEN: BOT_TOKEN,
-} = requireEnv(
-  [
-    "SUPABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
-    "TELEGRAM_BOT_TOKEN",
-  ] as const,
-);
+const { TELEGRAM_BOT_TOKEN: BOT_TOKEN } = requireEnv([
+  "TELEGRAM_BOT_TOKEN",
+] as const);
 
-const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-  auth: { persistSession: false },
-});
+const supabaseAdmin = createClient();
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/data-retention-cron/index.ts
+++ b/supabase/functions/data-retention-cron/index.ts
@@ -1,7 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { ok } from "../_shared/http.ts";
-import { requireEnv } from "../_shared/env.ts";
 
 serve(async (req) => {
   const url = new URL(req.url);
@@ -9,13 +8,7 @@ serve(async (req) => {
     return ok({ name: "data-retention-cron", ts: new Date().toISOString() });
   }
   if (req.method === "HEAD") return new Response(null, { status: 200 });
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
-    requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const);
-  const supa = createClient(
-    SUPABASE_URL,
-    SUPABASE_SERVICE_ROLE_KEY,
-    { auth: { persistSession: false } },
-  );
+  const supa = createClient();
   const days = Number(Deno.env.get("RETENTION_DAYS") ?? "90");
   const cutoff = new Date(Date.now() - days * 86400000).toISOString();
 

--- a/supabase/functions/miniapp-health/index.ts
+++ b/supabase/functions/miniapp-health/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 interface SupabaseLike {
   from: (table: string) => {
@@ -50,12 +50,7 @@ async function handler(req: Request): Promise<Response> {
   const tg = String(body.telegram_id || "").trim();
   if (!tg) return new Response("Missing telegram_id", { status: 400 });
 
-  const url = getEnv("SUPABASE_URL");
-  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const { createClient } = await import(
-    "https://esm.sh/@supabase/supabase-js@2"
-  );
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   let isVip: boolean | null = null;
   try {

--- a/supabase/functions/ops-health/index.ts
+++ b/supabase/functions/ops-health/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { getEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
 serve(async (_req) => {
   const report: Record<string, unknown> = { ok: true, checks: {} };
@@ -23,11 +22,7 @@ serve(async (_req) => {
 
   // DB ping
   try {
-    const supa = createClient(
-      getEnv("SUPABASE_URL"),
-      getEnv("SUPABASE_SERVICE_ROLE_KEY"),
-      { auth: { persistSession: false } },
-    );
+    const supa = createClient();
     const { data, error } = await supa.from("bot_users").select("id").limit(1);
     report.checks!["db"] = !error;
     if (error) report.ok = false;

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { ok, mna, oops, unauth, bad, nf } from "../_shared/http.ts";
 import { verifyBinancePayment } from "./binance.ts";
 
@@ -45,11 +45,7 @@ serve(async (req) => {
       return mna();
     }
 
-    const supa = createClient(
-      need("SUPABASE_URL"),
-      need("SUPABASE_SERVICE_ROLE_KEY"),
-      { auth: { persistSession: false } },
-    );
+    const supa = createClient();
 
     // Pull tolerance & window from bot_settings (fallbacks)
     const { data: tolRow } = await supa.from("bot_settings").select(

--- a/supabase/functions/plans/index.ts
+++ b/supabase/functions/plans/index.ts
@@ -1,15 +1,12 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 serve(async (req) => {
   if (req.method !== "GET") {
     return new Response("Method Not Allowed", { status: 405 });
   }
 
-  const url = getEnv("SUPABASE_URL");
-  const anon = getEnv("SUPABASE_ANON_KEY");
-  const supa = createClient(url, anon, { auth: { persistSession: false } });
+  const supa = createClient("anon");
 
   const { data, error } = await supa
     .from("subscription_plans")

--- a/supabase/functions/receipt-ocr/index.ts
+++ b/supabase/functions/receipt-ocr/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 type Body = { payment_id: string };
 
@@ -60,11 +60,7 @@ serve(async (req) => {
     return new Response("Bad JSON", { status: 400 });
   }
 
-  const supa = createClient(
-    need("SUPABASE_URL"),
-    need("SUPABASE_SERVICE_ROLE_KEY"),
-    { auth: { persistSession: false } },
-  );
+  const supa = createClient();
 
   // Load payment + plan + receipt path
   const { data: p } = await supa.from("payments")

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 type Body = {
   telegram_id: string;
@@ -20,9 +19,7 @@ serve(async (req) => {
     return new Response("Bad JSON", { status: 400 });
   }
 
-  const url = getEnv("SUPABASE_URL");
-  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const { error } = await supa
     .from("payments")

--- a/supabase/functions/receipt-upload-url/index.ts
+++ b/supabase/functions/receipt-upload-url/index.ts
@@ -1,6 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { getEnv } from "../_shared/env.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 type Body = {
   telegram_id: string;
@@ -20,9 +19,7 @@ serve(async (req) => {
     return new Response("Bad JSON", { status: 400 });
   }
 
-  const url = getEnv("SUPABASE_URL");
-  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const key = `receipts/${body.telegram_id}/${crypto.randomUUID()}-${body.filename}`;
   const { data: signed, error } = await supa.storage

--- a/supabase/functions/rotate-webhook-secret/index.ts
+++ b/supabase/functions/rotate-webhook-secret/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { ok, mna, unauth, oops } from "../_shared/http.ts";
-import { requireEnv } from "../_shared/env.ts";
+import { getEnv, requireEnv } from "../_shared/env.ts";
 
 function genHex(n = 24) {
   const b = new Uint8Array(n);
@@ -34,10 +34,10 @@ serve(async (req) => {
       return unauth();
     }
 
-    const { SUPABASE_URL: url, SUPABASE_SERVICE_ROLE_KEY: svc, TELEGRAM_BOT_TOKEN: token } =
-      requireEnv(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TELEGRAM_BOT_TOKEN"] as const);
-    const supa = createClient(url, svc, { auth: { persistSession: false } });
-    const ref = (new URL(url)).hostname.split(".")[0];
+    const { TELEGRAM_BOT_TOKEN: token } =
+      requireEnv(["TELEGRAM_BOT_TOKEN"] as const);
+    const supa = createClient();
+    const ref = (new URL(getEnv("SUPABASE_URL"))).hostname.split(".")[0];
     const expectedUrl = `https://${ref}.functions.supabase.co/telegram-bot`;
 
     const secret = genHex(24);

--- a/supabase/functions/setup-webhook-helper/index.ts
+++ b/supabase/functions/setup-webhook-helper/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { need } from "../_shared/env.ts";
 import { ok, oops } from "../_shared/http.ts";
 import { ensureWebhookSecret } from "../_shared/telegram_secret.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -25,11 +25,10 @@ serve(async (req) => {
   try {
     const BOT_TOKEN = need("TELEGRAM_BOT_TOKEN");
     const SUPABASE_URL = need("SUPABASE_URL");
-    const SERVICE_KEY = need("SUPABASE_SERVICE_ROLE_KEY");
     const PROJECT_URL = SUPABASE_URL.replace("https://", "").replace(".supabase.co", "");
     const WEBHOOK_URL = `https://${PROJECT_URL}.functions.supabase.co/telegram-bot`;
 
-    const supa = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
+    const supa = createClient();
     const WEBHOOK_SECRET = await ensureWebhookSecret(supa);
 
     console.log(`Setting up webhook: ${WEBHOOK_URL}`);

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { getEnv } from "../_shared/env.ts";
 import { createLogger } from "../_shared/logger.ts";
 import { ensureWebhookSecret } from "../_shared/telegram_secret.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -32,8 +32,7 @@ serve(async (req) => {
     logger.info("Setting up Telegram webhook...");
 
     const supabaseUrl = getEnv("SUPABASE_URL");
-    const serviceKey = getEnv("SUPABASE_SERVICE_ROLE_KEY");
-    const supa = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
+    const supa = createClient();
     const secret = await ensureWebhookSecret(supa);
 
     // Get the webhook URL for our telegram-bot function

--- a/supabase/functions/subscriptions-cron/index.ts
+++ b/supabase/functions/subscriptions-cron/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { getEnv, EnvKey } from "../_shared/env.ts";
 
 function need(k: EnvKey) {
@@ -15,10 +15,8 @@ async function tgSend(token: string, chatId: string, text: string) {
 }
 
 serve(async (_req) => {
-  const url = need("SUPABASE_URL");
-  const svc = need("SUPABASE_SERVICE_ROLE_KEY");
   const bot = need("TELEGRAM_BOT_TOKEN");
-  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const supa = createClient();
 
   const now = new Date();
   const d7 = new Date(now);

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { unauth, ok } from "../_shared/http.ts";
 import { expectedSecret, readDbWebhookSecret } from "../_shared/telegram_secret.ts";
 
@@ -75,11 +75,7 @@ serve(async (req) => {
       `https://${ref}.functions.supabase.co/miniapp/`,
   );
 
-  const supa = createClient(
-    need("SUPABASE_URL"),
-    need("SUPABASE_SERVICE_ROLE_KEY"),
-    { auth: { persistSession: false } },
-  );
+  const supa = createClient();
   const token = need("TELEGRAM_BOT_TOKEN");
 
   const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1,25 +1,13 @@
 // Enhanced admin handlers for comprehensive table management
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient } from "../_shared/client.ts";
 import { optionalEnv, requireEnv } from "../_shared/env.ts";
 import { expectedSecret } from "../_shared/telegram_secret.ts";
 
-const {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-  TELEGRAM_BOT_TOKEN: BOT_TOKEN,
-} = requireEnv(
-  [
-    "SUPABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
-    "TELEGRAM_BOT_TOKEN",
-  ] as const,
-);
+const { TELEGRAM_BOT_TOKEN: BOT_TOKEN } = requireEnv([
+  "TELEGRAM_BOT_TOKEN",
+] as const);
 
-const supabaseAdmin = createClient(
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-  { auth: { persistSession: false } },
-);
+const supabaseAdmin = createClient();
 
 // Import utility functions
 import { getBotContent, logAdminAction } from "./database-utils.ts";

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -1,19 +1,7 @@
 // Database utility functions for the Telegram bot
-import { createClient } from "jsr:@supabase/supabase-js@2";
-import { requireEnv } from "../_shared/env.ts";
+import { createClient } from "../_shared/client.ts";
 
-const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-  [
-    "SUPABASE_URL",
-    "SUPABASE_SERVICE_ROLE_KEY",
-  ] as const,
-);
-
-const supabaseAdmin = createClient(
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-  { auth: { persistSession: false } },
-);
+const supabaseAdmin = createClient();
 
 interface VipPackage {
   id: string;

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5,6 +5,7 @@ import { json, mna, ok, oops } from "../_shared/http.ts";
 import { validateTelegramHeader } from "../_shared/telegram_secret.ts";
 import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getBotContent } from "./database-utils.ts";
+import { createClient } from "../_shared/client.ts";
 
 interface TelegramMessage {
   chat: { id: number };
@@ -61,12 +62,7 @@ async function getSupabase(): Promise<SupabaseClient | null> {
   if (supabaseAdmin) return supabaseAdmin;
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return null;
   try {
-    const { createClient } = await import(
-      "https://esm.sh/@supabase/supabase-js@2"
-    );
-    supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-      auth: { persistSession: false },
-    });
+    supabaseAdmin = createClient();
   } catch (_e) {
     supabaseAdmin = null;
   }

--- a/supabase/functions/telegram-webhook-keeper/index.ts
+++ b/supabase/functions/telegram-webhook-keeper/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { ensureWebhookSecret, readDbWebhookSecret } from "../_shared/telegram_secret.ts";
+import { createClient } from "../_shared/client.ts";
 
 function requireEnv(k: string) {
   const v = Deno.env.get(k);
@@ -36,14 +37,10 @@ async function handler(req: Request): Promise<Response> {
   }
 
   // Supabase + Telegram pre-reqs
-  const url = requireEnv("SUPABASE_URL");
-  const srv = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
   const token = requireEnv("TELEGRAM_BOT_TOKEN");
   const ref = projectRef();
   const expectedUrl = `https://${ref}.functions.supabase.co/telegram-bot`;
-
-  const { createClient } = await import("https://esm.sh/@supabase/supabase-js@2");
-  const supa = createClient(url, srv, { auth: { persistSession: false } });
+  const supa = createClient();
 
   // 1) Determine secret precedence: DB -> ENV -> generate
   const secret = await ensureWebhookSecret(supa);


### PR DESCRIPTION
## Summary
- add a shared Supabase client helper
- update edge functions to consume the shared helper

## Testing
- `npm test` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e831ff483228bc8c68275b99e77