### PR TITLE
feat(bot): greet returning Telegram users with package summary

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -55,6 +55,19 @@ async function createDefaultContent(
 💎 Join our VIP community
 
 👇 Choose what you need:`,
+    "welcome_back_message": `👋 Welcome back to Dynamic Capital VIP Bot!
+
+🔥 VIP Packages:
+• 1 Month – access to premium signals
+• 3 Months – best value plan
+• Lifetime – one-time payment for lifetime access
+
+Available commands:
+/start - Main menu
+/vip - View VIP packages
+/help - Show help
+/support - Contact support
+/about - About us`,
     "about_us": `🏢 About Dynamic Capital
 
 We are a leading trading education and signals provider with years of experience in financial markets.

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -352,7 +352,17 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
 
   // Early match for /start variants like "/start", "/start@Bot", or "/start foo"
   if (isStartMessage(msg)) {
-    const welcome = await getBotContent("welcome_message");
+    const supa = await getSupabase();
+    let contentKey = "welcome_message";
+    if (supa) {
+      const { data } = await supa
+        .from("bot_users")
+        .select("id")
+        .eq("telegram_id", msg.from?.id ?? chatId)
+        .maybeSingle();
+      if (data) contentKey = "welcome_back_message";
+    }
+    const welcome = await getBotContent(contentKey);
     if (welcome) await notifyUser(chatId, welcome);
     await handleStartPayload(msg);
     await sendMiniAppLink(chatId);

--- a/supabase/migrations/20250807023345_navy_boat.sql
+++ b/supabase/migrations/20250807023345_navy_boat.sql
@@ -49,6 +49,30 @@ VALUES (
   'system'
 ) ON CONFLICT (content_key) DO NOTHING;
 
+-- Insert default welcome back message for returning users
+INSERT INTO bot_content (content_key, content_value, content_type, description, is_active, created_by, last_modified_by)
+VALUES (
+  'welcome_back_message',
+  '👋 Welcome back to Dynamic Capital VIP Bot!
+
+🔥 VIP Packages:
+• 1 Month – access to premium signals
+• 3 Months – best value plan
+• Lifetime – one-time payment for lifetime access
+
+Available commands:
+/start - Main menu
+/vip - View VIP packages
+/help - Show help
+/support - Contact support
+/about - About us',
+  'text',
+  'Welcome message for returning users',
+  true,
+  'system',
+  'system'
+) ON CONFLICT (content_key) DO NOTHING;
+
 -- Insert other essential content entries
 INSERT INTO bot_content (content_key, content_value, content_type, description, is_active, created_by, last_modified_by)
 VALUES 


### PR DESCRIPTION
## Summary
- add `welcome_back_message` bot content with VIP package and command summary
- send returning users `welcome_back_message` instead of first-time `welcome_message`
- seed `welcome_back_message` in migrations

## Testing
- `npm test` *(fails: Missing required env: SUPABASE_ANON_KEY)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d7c4089408322a1bfdde564ca1624