### PR TITLE
chore: guard miniapp build output

### DIFF
--- a/scripts/miniapp-build-to-edge.sh
+++ b/scripts/miniapp-build-to-edge.sh
@@ -13,4 +13,8 @@ popd >/dev/null
 rm -rf "$EDGE_DIR"
 mkdir -p "$EDGE_DIR"
 cp -R "$OUT_DIR"/* "$EDGE_DIR/"
+if [ ! -s "$EDGE_DIR/index.html" ]; then
+  echo "Error: $EDGE_DIR/index.html is missing or empty" >&2
+  exit 1
+fi
 echo "Copied build to $EDGE_DIR"


### PR DESCRIPTION
## Summary
- fail miniapp build if the copied `index.html` is missing or empty

## Testing
- `bash scripts/miniapp-build-to-edge.sh`
- `supabase functions deploy miniapp` *(fails: command not found)*
- `npm test` *(fails: Uncaught error from miniapp_health_test, binance webhook tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_689d802da4e8832280de1694107f35eb