### PR TITLE
feat: add dashboard command

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -64,6 +64,7 @@ async function createDefaultContent(
 
 Available commands:
 /start - Main menu
+/dashboard - View account dashboard
 /packages - View VIP packages
 /vip - VIP benefits
 /help - Show help
@@ -90,6 +91,7 @@ Our support team is here to assist you!
 
 Available commands:
 /start - Main menu
+/dashboard - View account dashboard
 /packages - View VIP packages
 /vip - VIP benefits
 /help - Show this help


### PR DESCRIPTION
## Summary
- add /dashboard command showing subscription, promos, and top commands
- provide quick action buttons and callbacks
- document /dashboard in default help and welcome messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689daa1c04c4832288f29a5b340d9b82