### PR TITLE
feat: add optional icon prop to mini buttons

### DIFF
--- a/apps/mini/README.md
+++ b/apps/mini/README.md
@@ -18,3 +18,20 @@ The app lives under `apps/mini`. It relies on existing Edge Function endpoints:
 
 SVG placeholders live in `apps/mini/public` for the logo, bank tiles and QR
 frame; replace them with production assets as needed.
+
+## Icons
+
+Buttons such as `PrimaryButton`, `SecondaryButton`, `ApproveButton`, and `RejectButton` accept an optional `icon` prop. For a consistent look, import icons from the [Heroicons React](https://github.com/tailwindlabs/heroicons) package:
+
+```bash
+npm install @heroicons/react
+```
+
+```tsx
+import { CheckIcon } from "@heroicons/react/24/solid";
+import PrimaryButton from "./src/components/PrimaryButton";
+
+<PrimaryButton label="Continue" icon={<CheckIcon className="h-4 w-4" />} />;
+```
+
+Any `ReactNode` can be supplied if you prefer another icon library.

--- a/apps/mini/src/components/ApproveButton.tsx
+++ b/apps/mini/src/components/ApproveButton.tsx
@@ -1,15 +1,19 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
+  icon?: ReactNode;
 }
 
 export default function ApproveButton(
-  { label, className = "", ...rest }: Props,
+  { label, icon = null, className = "", ...rest }: Props,
 ) {
   return (
     <button className={`dc-btn dc-btn--approve ${className}`} {...rest}>
-      {label}
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
     </button>
   );
 }

--- a/apps/mini/src/components/PrimaryButton.tsx
+++ b/apps/mini/src/components/PrimaryButton.tsx
@@ -1,15 +1,19 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
+  icon?: ReactNode;
 }
 
 export default function PrimaryButton(
-  { label, className = "", ...rest }: Props,
+  { label, icon = null, className = "", ...rest }: Props,
 ) {
   return (
     <button className={`dc-btn dc-btn--primary ${className}`} {...rest}>
-      {label}
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
     </button>
   );
 }

--- a/apps/mini/src/components/RejectButton.tsx
+++ b/apps/mini/src/components/RejectButton.tsx
@@ -1,15 +1,19 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
+  icon?: ReactNode;
 }
 
 export default function RejectButton(
-  { label, className = "", ...rest }: Props,
+  { label, icon = null, className = "", ...rest }: Props,
 ) {
   return (
     <button className={`dc-btn dc-btn--reject ${className}`} {...rest}>
-      {label}
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
     </button>
   );
 }

--- a/apps/mini/src/components/SecondaryButton.tsx
+++ b/apps/mini/src/components/SecondaryButton.tsx
@@ -1,15 +1,19 @@
-import type { ButtonHTMLAttributes } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
+  icon?: ReactNode;
 }
 
 export default function SecondaryButton(
-  { label, className = "", ...rest }: Props,
+  { label, icon = null, className = "", ...rest }: Props,
 ) {
   return (
     <button className={`dc-btn dc-btn--glass ${className}`} {...rest}>
-      {label}
+      <span className="flex items-center gap-2">
+        {icon}
+        {label}
+      </span>
     </button>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -750,6 +751,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@heroicons/react": "^2.2.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.0",


### PR DESCRIPTION
## Summary
- allow `PrimaryButton`, `SecondaryButton`, `ApproveButton`, and `RejectButton` to render an optional icon before the label
- add Heroicons React dependency for consistent icons and document usage in the mini app README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dad5dc7808322bd8b40b592b7f5e5