### PR TITLE
feat(bank): add copy code button

### DIFF
--- a/apps/mini/src/pages/Bank.tsx
+++ b/apps/mini/src/pages/Bank.tsx
@@ -4,6 +4,7 @@ import NetworkPicker from "../components/NetworkPicker";
 import GlassPanel from "../components/GlassPanel";
 import ReceiptUploader from "../components/ReceiptUploader";
 import PrimaryButton from "../components/PrimaryButton";
+import SecondaryButton from "../components/SecondaryButton";
 import { useApi } from "../hooks/useApi";
 import { useTelegramMainButton } from "../hooks/useTelegram";
 
@@ -12,6 +13,7 @@ export default function Bank() {
   const [bank, setBank] = useState("");
   const [payCode, setPayCode] = useState("");
   const [file, setFile] = useState<File | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (bank) {
@@ -20,6 +22,16 @@ export default function Bank() {
       );
     }
   }, [bank, api]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(payCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (e) {
+      // no-op if clipboard isn't available
+    }
+  };
 
   const handleSubmit = async () => {
     if (file) {
@@ -40,7 +52,16 @@ export default function Bank() {
       {payCode && (
         <GlassPanel className="mt-4 text-center">
           <p>Your deposit code</p>
-          <p className="font-mono text-lg">{payCode}</p>
+          <div className="flex items-center justify-center gap-2">
+            <span className="font-mono text-lg">{payCode}</span>
+            <SecondaryButton
+              type="button"
+              label={copied ? "Copied!" : "Copy code"}
+              aria-label="Copy code"
+              onClick={handleCopy}
+              className="px-2 py-1 text-xs"
+            />
+          </div>
           <p className="text-sm">Add this in Remarks</p>
         </GlassPanel>
       )}


### PR DESCRIPTION
## Summary
- add small copy button next to bank deposit code
- copy pay code to clipboard with temporary "Copied!" feedback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dad5f23e88322b5deb7e98d828d38