### PR TITLE
Use text arrays for package and plan fields

### DIFF
--- a/supabase/migrations/20250813093000_convert_arrays_to_text.sql
+++ b/supabase/migrations/20250813093000_convert_arrays_to_text.sql
@@ -38,3 +38,20 @@ BEGIN
   END IF;
 EXCEPTION WHEN others THEN NULL;
 END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='subscription_plans'
+      AND column_name='features'
+      AND data_type='jsonb'
+  ) THEN
+    ALTER TABLE public.subscription_plans
+      ALTER COLUMN features TYPE text[] USING
+        CASE WHEN features IS NULL THEN ARRAY[]::text[]
+             ELSE ARRAY(SELECT jsonb_array_elements_text(features)) END;
+  END IF;
+EXCEPTION WHEN others THEN NULL;
+END $$;

--- a/supabase/migrations/20250814000000_use_text_arrays.sql
+++ b/supabase/migrations/20250814000000_use_text_arrays.sql
@@ -1,4 +1,4 @@
--- Ensure array fields use text[] for education packages and user package assignments
+-- Ensure array fields use text[] for education packages, subscription plans, and user package assignments
 DO $$
 BEGIN
   IF EXISTS (
@@ -44,7 +44,26 @@ BEGIN
         CASE
           WHEN telegram_channels IS NULL THEN ARRAY[]::text[]
           WHEN pg_typeof(telegram_channels)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(telegram_channels))
-          ELSE string_to_array(telegram_channels::text, ',')
+      ELSE string_to_array(telegram_channels::text, ',')
+        END;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='subscription_plans'
+      AND column_name='features'
+      AND data_type <> 'ARRAY'
+  ) THEN
+    ALTER TABLE public.subscription_plans
+      ALTER COLUMN features TYPE text[] USING
+        CASE
+          WHEN features IS NULL THEN ARRAY[]::text[]
+          WHEN pg_typeof(features)::text = 'jsonb' THEN ARRAY(SELECT jsonb_array_elements_text(features))
+          ELSE string_to_array(features::text, ',')
         END;
   END IF;
 END $$;


### PR DESCRIPTION
## Summary
- enforce text[] arrays for education package features, requirements, and learning outcomes
- ensure user package assignments store telegram_channels as text[] arrays
- convert subscription plan features column to text[] arrays

## Testing
- `npm test` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db561a5cc832287ac36352407d00b