### PR TITLE
Specify ON DELETE actions for foreign keys

### DIFF
--- a/supabase/migrations/20250811_connect_bot_users_fks.sql
+++ b/supabase/migrations/20250811_connect_bot_users_fks.sql
@@ -86,68 +86,68 @@ WHERE sv.bot_user_id IS NULL AND bu.telegram_id = sv.telegram_user_id;
 DO $$ BEGIN
   ALTER TABLE public.promo_analytics
     ADD CONSTRAINT promo_analytics_plan_id_fkey
-    FOREIGN KEY (plan_id) REFERENCES public.subscription_plans(id) NOT VALID;
+    FOREIGN KEY (plan_id) REFERENCES public.subscription_plans(id) ON DELETE SET NULL NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.user_surveys
     ADD CONSTRAINT user_surveys_recommended_plan_id_fkey
-    FOREIGN KEY (recommended_plan_id) REFERENCES public.subscription_plans(id) NOT VALID;
+    FOREIGN KEY (recommended_plan_id) REFERENCES public.subscription_plans(id) ON DELETE SET NULL NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 -- 4) Add FKs to bot_users (use NOT VALID, then VALIDATE after backfill)
 DO $$ BEGIN
   ALTER TABLE public.user_subscriptions
     ADD CONSTRAINT user_subscriptions_bot_user_id_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.conversion_tracking
     ADD CONSTRAINT conversion_tracking_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.promo_analytics
     ADD CONSTRAINT promo_analytics_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.promotion_usage
     ADD CONSTRAINT promotion_usage_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.user_interactions
     ADD CONSTRAINT user_interactions_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.user_sessions
     ADD CONSTRAINT user_sessions_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.channel_memberships
     ADD CONSTRAINT channel_memberships_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.education_enrollments
     ADD CONSTRAINT education_enrollments_bot_user_fkey
-    FOREIGN KEY (student_bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (student_bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   ALTER TABLE public.user_surveys
     ADD CONSTRAINT user_surveys_bot_user_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) NOT VALID;
+    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE NOT VALID;
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 -- 5) Validate new FKs (will fail if orphans remain; keep NOT VALID in that case)

--- a/supabase/migrations/20250813091237_schema_hardening.sql
+++ b/supabase/migrations/20250813091237_schema_hardening.sql
@@ -60,9 +60,10 @@ WHERE cm.bot_user_id IS NULL
 DO $$
 BEGIN
   ALTER TABLE public.channel_memberships
-    ADD CONSTRAINT channel_memberships_bot_user_id_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+    DROP CONSTRAINT IF EXISTS channel_memberships_bot_user_id_fkey,
+    ADD  CONSTRAINT channel_memberships_bot_user_id_fkey
+      FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE;
+EXCEPTION WHEN others THEN NULL;
 END$$;
 
 -- 3b) user_package_assignments: add bot_user_id, backfill via profiles
@@ -79,9 +80,10 @@ WHERE upa.bot_user_id IS NULL
 DO $$
 BEGIN
   ALTER TABLE public.user_package_assignments
-    ADD CONSTRAINT user_package_assignments_bot_user_id_fkey
-    FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id);
-EXCEPTION WHEN duplicate_object THEN NULL;
+    DROP CONSTRAINT IF EXISTS user_package_assignments_bot_user_id_fkey,
+    ADD  CONSTRAINT user_package_assignments_bot_user_id_fkey
+      FOREIGN KEY (bot_user_id) REFERENCES public.bot_users(id) ON DELETE CASCADE;
+EXCEPTION WHEN others THEN NULL;
 END$$;
 
 -- 4) ON DELETE rules
@@ -90,7 +92,16 @@ BEGIN
   ALTER TABLE public.payments
     DROP CONSTRAINT IF EXISTS payments_user_id_fkey,
     ADD  CONSTRAINT payments_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES public.bot_users(id) ON DELETE RESTRICT;
+    FOREIGN KEY (user_id) REFERENCES public.bot_users(id) ON DELETE SET NULL;
+EXCEPTION WHEN others THEN NULL;
+END$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.payments
+    DROP CONSTRAINT IF EXISTS payments_plan_id_fkey,
+    ADD  CONSTRAINT payments_plan_id_fkey
+    FOREIGN KEY (plan_id) REFERENCES public.subscription_plans(id) ON DELETE SET NULL;
 EXCEPTION WHEN others THEN NULL;
 END$$;
 
@@ -109,6 +120,15 @@ BEGIN
     DROP CONSTRAINT IF EXISTS channel_memberships_package_id_fkey,
     ADD  CONSTRAINT channel_memberships_package_id_fkey
     FOREIGN KEY (package_id) REFERENCES public.subscription_plans(id) ON DELETE SET NULL;
+EXCEPTION WHEN others THEN NULL;
+END$$;
+
+DO $$
+BEGIN
+  ALTER TABLE public.channel_memberships
+    DROP CONSTRAINT IF EXISTS channel_memberships_user_id_fkey,
+    ADD  CONSTRAINT channel_memberships_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public.profiles(id) ON DELETE CASCADE;
 EXCEPTION WHEN others THEN NULL;
 END$$;
 


### PR DESCRIPTION
## Summary
- enforce ON DELETE SET NULL for plan references and ON DELETE CASCADE for bot user links in `connect_bot_users_fks` migration
- refine schema hardening migration with cascade/delete-null rules for payments, channel memberships, user package assignments, and current plan tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689db56dad708322a85dfdd3aefee355