### PR TITLE
chore: add B-tree indexes for key foreign keys

### DIFF
--- a/docs/supabase-audit-report.md
+++ b/docs/supabase-audit-report.md
@@ -189,9 +189,13 @@ Expected additional functions may be:
 - **User lookups**: `idx_bot_users_telegram_id`
 - **Active sessions**: `idx_bot_sessions_active`
 - **Payment status**: `idx_payments_status`
+- **Payment lookups**: `idx_payments_user_id`, `idx_payments_plan_id`
 - **VIP users**: `idx_bot_users_vip`
 - **Admin users**: `idx_bot_users_admin_vip`
 - **Subscription status**: `idx_user_subscriptions_active`
+- **Subscription lookups**: `idx_user_subscriptions_telegram_user_id`, `idx_user_subscriptions_plan_id`
+- **Enrollment packages**: `idx_education_enrollments_package_id`
+- **Package assignments**: `idx_user_package_assignments_bot_user_id`
 
 ### ✅ **Composite Indexes**
 

--- a/supabase/migrations/20250817000000_add_btree_indexes.sql
+++ b/supabase/migrations/20250817000000_add_btree_indexes.sql
@@ -1,0 +1,13 @@
+-- Ensure B-tree indexes on key foreign key columns for performance
+CREATE INDEX IF NOT EXISTS idx_bot_users_telegram_id ON public.bot_users USING BTREE (telegram_id);
+
+CREATE INDEX IF NOT EXISTS idx_payments_user_id ON public.payments USING BTREE (user_id);
+CREATE INDEX IF NOT EXISTS idx_payments_plan_id ON public.payments USING BTREE (plan_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_telegram_user_id ON public.user_subscriptions USING BTREE (telegram_user_id);
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_plan_id ON public.user_subscriptions USING BTREE (plan_id);
+
+CREATE INDEX IF NOT EXISTS idx_education_enrollments_package_id ON public.education_enrollments USING BTREE (package_id);
+
+-- Additional frequently queried foreign key
+CREATE INDEX IF NOT EXISTS idx_user_package_assignments_bot_user_id ON public.user_package_assignments USING BTREE (bot_user_id);


### PR DESCRIPTION
## Summary
- ensure B-tree indexes on telegram, payment, subscription, and enrollment foreign keys
- document new indexes in audit report

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689db56c43e483228958adbcb2f5ded2