### PR TITLE
refactor: use runtime flag for broadcast

### DIFF
--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -1,4 +1,5 @@
 import { enqueue } from "../queue/index.ts";
+import { getFlag } from "../utils/config.ts";
 
 export interface PlanBroadcastOptions {
   segment: number[] | { userIds: number[] };
@@ -6,11 +7,6 @@ export interface PlanBroadcastOptions {
   media?: string;
   chunkSize?: number;
   pauseMs?: number;
-}
-
-const featureFlags = { broadcasts_enabled: true };
-export function setBroadcastsEnabled(v: boolean) {
-  featureFlags.broadcasts_enabled = v;
 }
 
 export async function resolveTargets(
@@ -28,7 +24,7 @@ function sleep(ms: number) {
 }
 
 export async function planBroadcast(opts: PlanBroadcastOptions) {
-  if (!featureFlags.broadcasts_enabled) {
+  if (!(await getFlag("broadcasts_enabled"))) {
     throw new Error("Broadcasts disabled");
   }
   const { segment, text, media, chunkSize = 25, pauseMs = 500 } = opts;

--- a/tests/broadcast-queue.test.ts
+++ b/tests/broadcast-queue.test.ts
@@ -25,7 +25,8 @@ import {
   startWorker,
   stopWorker,
 } from "../src/queue/index.ts";
-import { planBroadcast, setBroadcastsEnabled } from "../src/broadcast/index.ts";
+import { planBroadcast } from "../src/broadcast/index.ts";
+import { setFlag, publish } from "../src/utils/config.ts";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -53,6 +54,8 @@ registerTest("retries until success", async () => {
 registerTest("chunking creates 8 jobs for 200 recipients", async () => {
   clearQueue();
   const ids = Array.from({ length: 200 }, (_, i) => i + 1);
+  await setFlag("broadcasts_enabled", true);
+  await publish();
   await planBroadcast({
     segment: ids,
     text: "hello",
@@ -70,8 +73,10 @@ registerTest("chunking creates 8 jobs for 200 recipients", async () => {
 
 registerTest("broadcasts disabled blocks planning", async () => {
   clearQueue();
-  setBroadcastsEnabled(false);
+  await setFlag("broadcasts_enabled", false);
+  await publish();
   const ids = [1, 2, 3];
   await assertRejects(() => planBroadcast({ segment: ids, text: "nope" }));
-  setBroadcastsEnabled(true);
+  await setFlag("broadcasts_enabled", true);
+  await publish();
 });


### PR DESCRIPTION
## Summary
- check runtime feature flag for broadcasts instead of local state
- remove `setBroadcastsEnabled` API
- update broadcast queue tests to toggle the flag via `setFlag`/`publish`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dbbb288648322bc8a5a1e28427334