### PR TITLE
feat: guard features with runtime flags

### DIFF
--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -1,4 +1,5 @@
 import { enqueue } from "../queue/index.ts";
+import { getFlag } from "../utils/config.ts";
 
 export interface PlanBroadcastOptions {
   segment: number[] | { userIds: number[] };
@@ -6,11 +7,6 @@ export interface PlanBroadcastOptions {
   media?: string;
   chunkSize?: number;
   pauseMs?: number;
-}
-
-const featureFlags = { broadcasts_enabled: true };
-export function setBroadcastsEnabled(v: boolean) {
-  featureFlags.broadcasts_enabled = v;
 }
 
 export async function resolveTargets(
@@ -28,7 +24,7 @@ function sleep(ms: number) {
 }
 
 export async function planBroadcast(opts: PlanBroadcastOptions) {
-  if (!featureFlags.broadcasts_enabled) {
+  if (!(await getFlag("broadcasts_enabled"))) {
     throw new Error("Broadcasts disabled");
   }
   const { segment, text, media, chunkSize = 25, pauseMs = 500 } = opts;

--- a/supabase/functions/binance-pay-webhook/index.ts
+++ b/supabase/functions/binance-pay-webhook/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 import { optionalEnv } from "../_shared/env.ts";
 import { createLogger } from "../_shared/logger.ts";
+import { getFlag } from "../../../src/utils/config.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -57,6 +58,14 @@ export async function handler(req: Request): Promise<Response> {
   }
 
   const logger = getLogger(req);
+
+  if (!(await getFlag("payments_enabled"))) {
+    logger.info("Payments feature disabled");
+    return new Response(
+      JSON.stringify({ success: false, message: "Payments disabled" }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
 
   try {
     const rawBody = await req.text();

--- a/tests/binance-pay-webhook.live.test.ts
+++ b/tests/binance-pay-webhook.live.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setFlag, publish } from "../src/utils/config.ts";
 
 // compute HMAC SHA-512 signature for Binance headers
 async function sign(secret: string, timestamp: string, nonce: string, body: string) {
@@ -29,6 +30,8 @@ denoEnvCleanup();
 
 denoTest("binance webhook completes payment and updates DB", async () => {
   setEnv();
+  await setFlag("payments_enabled", true);
+  await publish();
   const { calls, restore } = mockTelegram();
   try {
     const payments = [{
@@ -72,11 +75,15 @@ denoTest("binance webhook completes payment and updates DB", async () => {
     restore();
     cleanup();
     await new Promise((r) => setTimeout(r, 0));
+    await setFlag("payments_enabled", false);
+    await publish();
   }
 });
 
 denoTest("binance webhook rejects invalid signature", async () => {
   setEnv();
+  await setFlag("payments_enabled", true);
+  await publish();
   const { restore } = mockTelegram();
   try {
     const payments = [{
@@ -112,11 +119,15 @@ denoTest("binance webhook rejects invalid signature", async () => {
     restore();
     cleanup();
     await new Promise((r) => setTimeout(r, 0));
+     await setFlag("payments_enabled", false);
+     await publish();
   }
 });
 
 denoTest("binance webhook errors when payment missing", async () => {
   setEnv();
+  await setFlag("payments_enabled", true);
+  await publish();
   const { restore } = mockTelegram();
   try {
     const payments: any[] = [];
@@ -145,6 +156,8 @@ denoTest("binance webhook errors when payment missing", async () => {
     restore();
     cleanup();
     await new Promise((r) => setTimeout(r, 0));
+    await setFlag("payments_enabled", false);
+    await publish();
   }
 });
 

--- a/tests/broadcast-queue.test.ts
+++ b/tests/broadcast-queue.test.ts
@@ -25,7 +25,8 @@ import {
   startWorker,
   stopWorker,
 } from "../src/queue/index.ts";
-import { planBroadcast, setBroadcastsEnabled } from "../src/broadcast/index.ts";
+import { planBroadcast } from "../src/broadcast/index.ts";
+import { setFlag, publish } from "../src/utils/config.ts";
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -52,6 +53,8 @@ registerTest("retries until success", async () => {
 
 registerTest("chunking creates 8 jobs for 200 recipients", async () => {
   clearQueue();
+  await setFlag("broadcasts_enabled", true);
+  await publish();
   const ids = Array.from({ length: 200 }, (_, i) => i + 1);
   await planBroadcast({
     segment: ids,
@@ -70,8 +73,10 @@ registerTest("chunking creates 8 jobs for 200 recipients", async () => {
 
 registerTest("broadcasts disabled blocks planning", async () => {
   clearQueue();
-  setBroadcastsEnabled(false);
+  await setFlag("broadcasts_enabled", false);
+  await publish();
   const ids = [1, 2, 3];
   await assertRejects(() => planBroadcast({ segment: ids, text: "nope" }));
-  setBroadcastsEnabled(true);
+  await setFlag("broadcasts_enabled", true);
+  await publish();
 });

--- a/tests/feature-blocks.test.ts
+++ b/tests/feature-blocks.test.ts
@@ -1,0 +1,101 @@
+// @ts-nocheck: cross-runtime test uses dynamic imports
+let registerTest, assertEquals;
+if (typeof Deno !== "undefined") {
+  registerTest = (name, fn) => Deno.test(name, fn);
+  const asserts = await import("https://deno.land/std@0.224.0/testing/asserts.ts");
+  assertEquals = asserts.assertEquals;
+} else {
+  const { test } = await import("node:test");
+  registerTest = (name, fn) => test(name, { concurrency: false }, fn);
+  const assert = (await import("node:assert")).strict;
+  assertEquals = (a, b, msg) => assert.equal(a, b, msg);
+}
+
+import { setFlag, publish } from "../src/utils/config.ts";
+
+registerTest("payments flag blocks webhook", async () => {
+  await setFlag("payments_enabled", false);
+  await publish();
+  (globalThis as any).__TEST_ENV__ = {
+    SUPABASE_URL: "x",
+    SUPABASE_ANON_KEY: "x",
+    SUPABASE_SERVICE_ROLE_KEY: "x",
+  };
+  const { handler } = await import(
+    "../supabase/functions/binance-pay-webhook/index.ts"
+  );
+  const req = new Request("https://example.com", { method: "POST", body: "{}" });
+  const res = await handler(req);
+  const data = await res.json();
+  assertEquals(data.success, false);
+  delete (globalThis as any).__TEST_ENV__;
+  await setFlag("payments_enabled", true);
+  await publish();
+});
+
+registerTest("mini app flag blocks link", async () => {
+  if (typeof Deno !== "undefined") {
+    Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = "tbot";
+  }
+  (globalThis as any).__TEST_ENV__ = {
+    SUPABASE_URL: "x",
+    SUPABASE_ANON_KEY: "x",
+    SUPABASE_SERVICE_ROLE_KEY: "x",
+  };
+  await setFlag("mini_app_enabled", false);
+  await publish();
+  const { sendMiniAppLink } = await import(
+    "../supabase/functions/telegram-bot/index.ts"
+  );
+  let called = false;
+  const orig = globalThis.fetch;
+  globalThis.fetch = async () => {
+    called = true;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    await sendMiniAppLink(123);
+    assertEquals(called, false);
+  } finally {
+    globalThis.fetch = orig;
+    delete (globalThis as any).__TEST_ENV__;
+  }
+  await setFlag("mini_app_enabled", true);
+  await publish();
+});
+
+registerTest("vip sync flag blocks pipeline", async () => {
+  if (typeof Deno !== "undefined") {
+    Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  } else {
+    process.env.TELEGRAM_BOT_TOKEN = "tbot";
+  }
+  (globalThis as any).__TEST_ENV__ = {
+    SUPABASE_URL: "x",
+    SUPABASE_ANON_KEY: "x",
+    SUPABASE_SERVICE_ROLE_KEY: "x",
+  };
+  await setFlag("vip_sync_enabled", false);
+  await publish();
+  const { startReceiptPipeline } = await import(
+    "../supabase/functions/telegram-bot/index.ts"
+  );
+  let text = "";
+  const orig = globalThis.fetch;
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(init?.body ?? "{}");
+    text = body.text;
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    await startReceiptPipeline({ message: { chat: { id: 1 } } });
+    assertEquals(text, "VIP sync is currently disabled.");
+  } finally {
+    globalThis.fetch = orig;
+    delete (globalThis as any).__TEST_ENV__;
+  }
+  await setFlag("vip_sync_enabled", true);
+  await publish();
+});

--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertMatch } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setFlag, publish } from "../src/utils/config.ts";
 
 const supaState = { tables: {} as Record<string, any[]> };
 (globalThis as any).__SUPA_MOCK__ = supaState;
@@ -22,6 +23,8 @@ function cleanup() {
 
 Deno.test("/start shows menu buttons for new users", async () => {
   setEnv();
+  await setFlag("mini_app_enabled", true);
+  await publish();
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -60,11 +63,15 @@ Deno.test("/start shows menu buttons for new users", async () => {
   } finally {
     globalThis.fetch = originalFetch;
     cleanup();
+    await setFlag("mini_app_enabled", false);
+    await publish();
   }
 });
 
 Deno.test("/start shows packages/promos for returning users", async () => {
   setEnv();
+  await setFlag("mini_app_enabled", true);
+  await publish();
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
@@ -99,5 +106,7 @@ Deno.test("/start shows packages/promos for returning users", async () => {
   } finally {
     globalThis.fetch = originalFetch;
     cleanup();
+    await setFlag("mini_app_enabled", false);
+    await publish();
   }
 });

--- a/tests/z-binance-pay-webhook.test.ts
+++ b/tests/z-binance-pay-webhook.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setFlag, publish } from "../src/utils/config.ts";
 
 // helper to compute HMAC SHA-512 signature
 async function sign(secret: string, timestamp: string, nonce: string, body: string) {
@@ -28,6 +29,8 @@ function setupTelegramMock() {
 }
 
 Deno.test("binance webhook processes successful payment", async () => {
+  await setFlag("payments_enabled", true);
+  await publish();
   Deno.env.set("SUPABASE_URL", "https://supabase.test");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
@@ -76,10 +79,14 @@ Deno.test("binance webhook processes successful payment", async () => {
   } finally {
     restore();
     await new Promise((r) => setTimeout(r, 0));
+    await setFlag("payments_enabled", false);
+    await publish();
   }
 });
 
 Deno.test("binance webhook rejects invalid signature", async () => {
+  await setFlag("payments_enabled", true);
+  await publish();
   Deno.env.set("SUPABASE_URL", "https://supabase.test");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
@@ -113,5 +120,7 @@ Deno.test("binance webhook rejects invalid signature", async () => {
   } finally {
     restore();
     await new Promise((r) => setTimeout(r, 0));
+    await setFlag("payments_enabled", false);
+    await publish();
   }
 });


### PR DESCRIPTION
## Summary
- gate Binance Pay webhook behind `payments_enabled`
- guard broadcasts, Mini App, and VIP sync behind feature flags
- add tests ensuring feature flags block their features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dbbaa538083229f9f5d9039744e03