### PR TITLE
feat: add Telegram menu navigation helpers

### DIFF
--- a/tests/telegram-bot-direct-photo.test.ts
+++ b/tests/telegram-bot-direct-photo.test.ts
@@ -9,6 +9,7 @@ function setEnv() {
   Deno.env.set("SUPABASE_URL", "http://local");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
 }
 
 function cleanup() {
@@ -17,6 +18,7 @@ function cleanup() {
   Deno.env.delete("SUPABASE_URL");
   Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
   Deno.env.delete("TELEGRAM_BOT_USERNAME");
+  Deno.env.delete("SUPABASE_ANON_KEY");
   supaState.tables = {} as Record<string, any[]>;
 }
 

--- a/tests/verify-initdata-handler.test.ts
+++ b/tests/verify-initdata-handler.test.ts
@@ -3,15 +3,22 @@ import { setTestEnv, makeTelegramInitData } from "../supabase/functions/_tests/h
 import { handler } from "../supabase/functions/verify-initdata/index.ts";
 
 Deno.test("verify-initdata handler accepts valid payload", async () => {
-  setTestEnv({ TELEGRAM_BOT_TOKEN: "test-token" });
-  const initData = await makeTelegramInitData({ id: 123, username: "alice" }, "test-token");
-  const req = new Request("http://local/verify-initdata", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ initData }),
-  });
-  const res = await handler(req);
-  assertEquals(res.status, 200);
-  const json = await res.json();
-  assertEquals(json, { ok: true });
+  const token = "test-token";
+  setTestEnv({ TELEGRAM_BOT_TOKEN: token });
+  Deno.env.set("TELEGRAM_BOT_TOKEN", token);
+  try {
+    const initData = await makeTelegramInitData({ id: 123, username: "alice" }, token);
+    const req = new Request("http://local/verify-initdata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ initData }),
+    });
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json, { ok: true });
+  } finally {
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+    delete (globalThis as any).__TEST_ENV__;
+  }
 });

--- a/tests/z-binance-pay-webhook.test.ts
+++ b/tests/z-binance-pay-webhook.test.ts
@@ -34,6 +34,7 @@ Deno.test("binance webhook processes successful payment", async () => {
   Deno.env.set("SUPABASE_URL", "https://supabase.test");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   Deno.env.set("BINANCE_SECRET_KEY", "shhh");
 
   const payments = [{
@@ -78,6 +79,7 @@ Deno.test("binance webhook processes successful payment", async () => {
     assertEquals(bot_users[0].is_vip, true);
   } finally {
     restore();
+    Deno.env.delete("SUPABASE_ANON_KEY");
     await new Promise((r) => setTimeout(r, 0));
     await setFlag("payments_enabled", false);
     await publish();
@@ -90,6 +92,7 @@ Deno.test("binance webhook rejects invalid signature", async () => {
   Deno.env.set("SUPABASE_URL", "https://supabase.test");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
   Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   Deno.env.set("BINANCE_SECRET_KEY", "shhh");
   const payments = [{ id: "p1", user_id: 100, plan_id: "plan1", status: "pending", subscription_plans: { is_lifetime: false, duration_months: 1, name: "Basic" } }];
   const bot_users = [{ id: "u1", telegram_id: 100, is_vip: false, current_plan_id: null, subscription_expires_at: null }];
@@ -119,6 +122,7 @@ Deno.test("binance webhook rejects invalid signature", async () => {
     assertEquals(bot_users[0].is_vip, false);
   } finally {
     restore();
+    Deno.env.delete("SUPABASE_ANON_KEY");
     await new Promise((r) => setTimeout(r, 0));
     await setFlag("payments_enabled", false);
     await publish();

--- a/tests/z-telegram-payment-approval.test.ts
+++ b/tests/z-telegram-payment-approval.test.ts
@@ -32,6 +32,7 @@ function setupTelegramMock() {
 Deno.test("admin approves payment via telegram", async () => {
   Deno.env.set("SUPABASE_URL", "https://supabase.test");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
   Deno.env.set("TELEGRAM_ADMIN_IDS", "999");
 
@@ -58,6 +59,7 @@ Deno.test("admin approves payment via telegram", async () => {
     assertEquals(user_subscriptions.length, 1);
   } finally {
     restore();
+    Deno.env.delete("SUPABASE_ANON_KEY");
     await new Promise((r) => setTimeout(r, 0));
   }
 });


### PR DESCRIPTION
## Summary
- add helpers to edit messages and answer callback queries
- add menu view builder and main menu sender
- support menu navigation via callback queries in telegram bot
- inject SUPABASE_ANON_KEY in tests to prevent missing env failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de26904288322b14ab4ffc67d0997