### PR TITLE
feat(bot): add menu command and mini app URL check

### DIFF
--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -61,10 +61,8 @@ Deno.test("/start shows menu buttons for new users", async () => {
     const first = JSON.parse(calls[0].body);
     assertEquals(first.text, "Welcome new user");
     const second = JSON.parse(calls[1].body);
-    assertEquals(
-      second.reply_markup.inline_keyboard[0][0].web_app.url,
-      "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/",
-    );
+    assertEquals(second.text, "Welcome! Choose an option:");
+    assertEquals(second.reply_markup.inline_keyboard[0][0].text, "Home");
   } finally {
     globalThis.fetch = originalFetch;
     cleanup();


### PR DESCRIPTION
## Summary
- verify MINI_APP_URL is HTTPS before showing the main menu
- add /menu command for quick access to the main menu
- adjust start-handler test for new menu-first behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de63594408322832e0ef764601b45