### PR TITLE
Handle callback queries early

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -909,6 +909,11 @@ export async function serveWebhook(req: Request): Promise<Response> {
     }
     const update = body as TelegramUpdate;
 
+    if (update.callback_query) {
+      await handleCallback(update);
+      return ok({ handled: true, kind: "callback_query" });
+    }
+
     // ---- BAN CHECK (short-circuit early) ----
     const supa = await supaSvc();
     const fromId = String(
@@ -943,8 +948,9 @@ export async function serveWebhook(req: Request): Promise<Response> {
       );
     }
 
-    await handleCommand(update);
-    await handleCallback(update);
+    if (!update.callback_query) {
+      await handleCommand(update);
+    }
 
     const fileId = isDirectMessage(update.message)
       ? getFileIdFromUpdate(update)


### PR DESCRIPTION
## Summary
- process callback queries immediately in telegram webhook
- avoid invoking command handler for callback interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689de818a1fc8322a52fa742b8a8b109