### PR TITLE
feat(bot): track menu message for editing

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -247,6 +247,7 @@ export type Database = {
           is_vip: boolean
           last_follow_up: string | null
           last_name: string | null
+          menu_message_id: number | null
           notes: string | null
           subscription_expires_at: string | null
           telegram_id: string
@@ -263,6 +264,7 @@ export type Database = {
           is_vip?: boolean
           last_follow_up?: string | null
           last_name?: string | null
+          menu_message_id?: number | null
           notes?: string | null
           subscription_expires_at?: string | null
           telegram_id: string
@@ -279,6 +281,7 @@ export type Database = {
           is_vip?: boolean
           last_follow_up?: string | null
           last_name?: string | null
+          menu_message_id?: number | null
           notes?: string | null
           subscription_expires_at?: string | null
           telegram_id?: string

--- a/types/telegram-bot.ts
+++ b/types/telegram-bot.ts
@@ -20,6 +20,7 @@ export interface BotUser {
   username?: string;
   first_name?: string;
   last_name?: string;
+  menu_message_id?: number;
   is_admin: boolean;
   is_vip: boolean;
   current_plan_id?: string;


### PR DESCRIPTION
## Summary
- persist main menu `message_id` per chat and reuse it via `showMainMenu`
- edit existing menu message on commands and callbacks instead of sending new ones
- extend Supabase types with `menu_message_id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df38c91e08322a77e9ac8c1001c51