### PR TITLE
Acknowledge feature flag callbacks

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -833,13 +833,14 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
   const data = cb.data || "";
   const userId = String(cb.from.id);
   try {
+    // Always acknowledge the callback to avoid client retries
+    await answerCallbackQuery(cb.id);
     if (data.startsWith("menu:")) {
       const section = data.slice("menu:".length) as
         | "home"
         | "plans"
         | "status"
         | "support";
-      await answerCallbackQuery(cb.id);
       await showMainMenu(chatId, section);
       return;
     }


### PR DESCRIPTION
## Summary
- avoid feature flag message spam by acknowledging Telegram callback queries

## Testing
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check tests/featureflags.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689e1300d13883229a573a74a2391a6a