### PR TITLE
feat: add promo command and package menu

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -403,6 +403,7 @@ export async function getFormattedVipPackages(): Promise<string> {
 
   message +=
     `✅ *Ready to level up your trading?*\nSelect a package below to get started!`;
+  message += `\n\n🎁 Have a promo code? Use /promo CODE to apply it.`;
 
   return message;
 }


### PR DESCRIPTION
## Summary
- rename main menu item to "Packages"
- add `/promo` command to list and apply active promotions
- mention promo usage in VIP package listing

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm test` *(fails: binance webhook completes payment and updates DB; binance webhook processes successful payment; admin approves payment via telegram)*

------
https://chatgpt.com/codex/tasks/task_e_689e175492bc8322b677e5903b920d79