### PR TITLE
feat(bot): add table management callbacks

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -965,6 +965,42 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         case "manage_table_subscription_plans":
           await handlers.handleSubscriptionPlansManagement(chatId, userId);
           break;
+        case "manage_table_plan_channels":
+          await handlers.handlePlanChannelsManagement(chatId, userId);
+          break;
+        case "manage_table_education_packages":
+          await handlers.handleEducationPackagesManagement(chatId, userId);
+          break;
+        case "manage_table_promotions":
+          await handlers.handlePromotionsManagement(chatId, userId);
+          break;
+        case "manage_table_bot_content":
+          await handlers.handleContentManagement(chatId, userId);
+          break;
+        case "manage_table_bot_settings":
+          await handlers.handleBotSettingsManagement(chatId, userId);
+          break;
+        case "manage_table_daily_analytics":
+          await handlers.handleDailyAnalyticsManagement(chatId, userId);
+          break;
+        case "manage_table_user_sessions":
+          await handlers.handleUserSessionsManagement(chatId, userId);
+          break;
+        case "manage_table_payments":
+          await handlers.handlePaymentsManagement(chatId, userId);
+          break;
+        case "manage_table_broadcast_messages":
+          await handlers.handleBroadcastMessagesManagement(chatId, userId);
+          break;
+        case "manage_table_bank_accounts":
+          await handlers.handleBankAccountsManagement(chatId, userId);
+          break;
+        case "manage_table_auto_reply_templates":
+          await handlers.handleAutoReplyTemplatesManagement(chatId, userId);
+          break;
+        case "export_all_tables":
+          await handlers.handleExportAllTables(chatId, userId);
+          break;
         case "table_stats_overview":
           await handlers.handleTableStatsOverview(chatId, userId);
           break;


### PR DESCRIPTION
## Summary
- wire up manage_table callbacks for all tables in Telegram bot

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "jsr:@supabase/supabase-js@2" from "src/utils/config.ts")*


------
https://chatgpt.com/codex/tasks/task_e_689e22fa483c8322b8cbe7d5c673e9fc