### PR TITLE
Serve landing page fallback for miniapp index

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -20,8 +20,9 @@ async function serveIndex(): Promise<Response> {
         new URL("./static/index.html", import.meta.url),
       );
     } catch (_) {
-      INDEX_HTML =
-        "<!doctype html><html><body>miniapp index missing</body></html>";
+      INDEX_HTML = await Deno.readTextFile(
+        new URL("./static/landing.html", import.meta.url),
+      );
     }
   }
 

--- a/supabase/functions/miniapp/static/landing.html
+++ b/supabase/functions/miniapp/static/landing.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chatty Bot Mini App</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <script type="module" crossorigin src="/assets/index-1-UrIGhz.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-voVKa_g2.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `landing.html` duplicate of miniapp `index.html`
- load `landing.html` as fallback when `index.html` is missing

## Testing
- `npm test`
- `curl http://localhost:8000/miniapp/`


------
https://chatgpt.com/codex/tasks/task_e_689e2b942e10832292d071c037b081fb