### PR TITLE
feat: add bank and crypto deposit pages

### DIFF
--- a/miniapp/src/App.tsx
+++ b/miniapp/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { initTelegramThemeHandlers } from "./theme";
 import { verify } from "./api";
+import Bank from "./Bank";
+import Crypto from "./Crypto";
 
 const MINI_APP_URL = (
   import.meta.env.VITE_MINI_APP_URL || window.location.origin + "/"
@@ -119,6 +121,7 @@ function SharedSections() {
 export default function App() {
   const [auth, setAuth] = useState<Auth | null>(null);
   const [error, setError] = useState(false);
+  const [page, setPage] = useState<"home" | "bank" | "crypto">("home");
 
   useEffect(() => {
     window.Telegram?.WebApp?.ready?.();
@@ -153,6 +156,9 @@ export default function App() {
       </div>
     );
   if (!auth) return <div className="p-4">Loading...</div>;
+
+  if (page === "bank") return <Bank onBack={() => setPage("home")} />;
+  if (page === "crypto") return <Crypto onBack={() => setPage("home")} />;
 
   const firstName = window.Telegram?.WebApp?.initDataUnsafe?.user?.first_name;
   const greeting = firstName ? `Welcome back, ${firstName}` : "Welcome";
@@ -215,6 +221,22 @@ export default function App() {
             className="px-3 py-1 rounded-full border"
           >
             Support
+          </button>
+        </div>
+        <div className="flex justify-center gap-2 mt-2 text-sm">
+          <button
+            type="button"
+            onClick={() => setPage("bank")}
+            className="px-3 py-1 rounded-full border"
+          >
+            Bank Deposit
+          </button>
+          <button
+            type="button"
+            onClick={() => setPage("crypto")}
+            className="px-3 py-1 rounded-full border"
+          >
+            Crypto Deposit
           </button>
         </div>
       </header>

--- a/miniapp/src/Bank.tsx
+++ b/miniapp/src/Bank.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { createIntent, uploadReceipt } from "./api";
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function Bank({ onBack }: Props) {
+  const [bank, setBank] = useState("");
+  const [payCode, setPayCode] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (bank) {
+      createIntent({ type: "bank", bank }).then((r) =>
+        setPayCode(r.pay_code),
+      );
+    }
+  }, [bank]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(payCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function handleSubmit() {
+    if (file) {
+      await uploadReceipt(file);
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-4 space-y-4 bg-background text-foreground">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold">Bank Deposit</h1>
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-3 py-1 rounded-lg border"
+        >
+          Back
+        </button>
+      </header>
+      <div className="space-y-2">
+        <label className="text-sm">Select bank</label>
+        <select
+          value={bank}
+          onChange={(e) => setBank(e.target.value)}
+          className="w-full p-2 border rounded-lg bg-card"
+        >
+          <option value="" disabled>
+            Choose bank
+          </option>
+          <option value="BML">BML</option>
+          <option value="MIB">MIB</option>
+        </select>
+      </div>
+      {payCode && (
+        <div className="p-4 border border-border rounded-lg bg-card text-center space-y-2">
+          <div>Your deposit code</div>
+          <div className="flex items-center justify-center gap-2">
+            <span className="font-mono text-lg">{payCode}</span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-2 py-1 text-xs rounded-lg border"
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+          <div className="text-sm">Add this in Remarks</div>
+        </div>
+      )}
+      <div className="space-y-2">
+        <label className="text-sm">Upload receipt</label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          className="w-full text-sm"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!file}
+        className="w-full py-3 rounded-lg bg-primary text-primary-foreground disabled:opacity-50"
+      >
+        Submit for verification
+      </button>
+    </div>
+  );
+}
+

--- a/miniapp/src/Crypto.tsx
+++ b/miniapp/src/Crypto.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { createIntent, submitTxid } from "./api";
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function Crypto({ onBack }: Props) {
+  const [network, setNetwork] = useState("TRON");
+  const [address, setAddress] = useState("");
+  const [txid, setTxid] = useState("");
+
+  useEffect(() => {
+    createIntent({ type: "crypto", network }).then((r) =>
+      setAddress(r.deposit_address),
+    );
+  }, [network]);
+
+  async function handleSubmit() {
+    if (txid) {
+      await submitTxid({ txid });
+    }
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(address);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-4 space-y-4 bg-background text-foreground">
+      <header className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold">Crypto Deposit</h1>
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-3 py-1 rounded-lg border"
+        >
+          Back
+        </button>
+      </header>
+      <div className="space-y-2">
+        <label className="text-sm">Network</label>
+        <select
+          value={network}
+          onChange={(e) => setNetwork(e.target.value)}
+          className="w-full p-2 border rounded-lg bg-card"
+        >
+          <option value="TRON">TRON/USDT</option>
+        </select>
+      </div>
+      {address && (
+        <div className="p-4 border border-border rounded-lg bg-card text-center space-y-2">
+          <div>Your deposit address</div>
+          <p className="break-all font-mono text-sm">{address}</p>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="px-2 py-1 text-xs rounded-lg border"
+          >
+            Copy address
+          </button>
+        </div>
+      )}
+      <div className="space-y-2">
+        <input
+          type="text"
+          placeholder="Paste TXID"
+          value={txid}
+          onChange={(e) => setTxid(e.target.value)}
+          className="w-full p-2 border rounded-lg bg-card"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!txid}
+        className="w-full py-3 rounded-lg bg-primary text-primary-foreground disabled:opacity-50"
+      >
+        Submit TXID
+      </button>
+    </div>
+  );
+}
+

--- a/miniapp/src/api.ts
+++ b/miniapp/src/api.ts
@@ -101,3 +101,41 @@ export async function getReferralLink(session_token: string, telegram_id: number
   return await r.json();
 }
 /* <<< DC BLOCK: api-core (end) */
+
+export async function createIntent(payload: Record<string, unknown>) {
+  const res = await fetch(`${base}/functions/v1/intent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      apikey: anonKey,
+      Authorization: `Bearer ${anonKey}`,
+    },
+    body: JSON.stringify({ initData: getInitData(), ...payload }),
+  });
+  return await res.json();
+}
+
+export async function uploadReceipt(file: File) {
+  const form = new FormData();
+  form.append("image", file);
+  form.append("initData", getInitData());
+  const res = await fetch(`${base}/functions/v1/receipt`, {
+    method: "POST",
+    headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` },
+    body: form,
+  });
+  return await res.json();
+}
+
+export async function submitTxid(payload: { txid: string }) {
+  const res = await fetch(`${base}/functions/v1/crypto-txid`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      apikey: anonKey,
+      Authorization: `Bearer ${anonKey}`,
+    },
+    body: JSON.stringify({ initData: getInitData(), ...payload }),
+  });
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- add bank and crypto deposit screens to mini miniapp
- extend API with endpoints for intents, receipt uploads, and TXID submission
- link deposit pages from landing page for easy navigation

## Testing
- `npm test`
- `npx eslint miniapp/src`
- `npm run lint` *(fails: Unexpected any. Specify a different type; Duplicate case label)*

------
https://chatgpt.com/codex/tasks/task_e_689e3885c33083229901a0572459e1ca