### PR TITLE
Load miniapp HTML from bundled file

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,6 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
-const INDEX_HTML = `<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Dynamic Capital VIP</title></head><body><h1>Dynamic Capital VIP Miniapp</h1></body></html>`;
+// Load the full mini app HTML from the static bundle on startup
+const INDEX_HTML = await Deno.readTextFile(
+  new URL("./static/index.html", import.meta.url),
+);
 
 const SECURITY_HEADERS = {
   "x-frame-options": "ALLOWALL", // Allow embedding in Telegram


### PR DESCRIPTION
## Summary
- load miniapp HTML from the static index.html bundle at startup
- serve the loaded HTML for `/`, `/miniapp`, and `/miniapp/` requests

## Testing
- `npm run lint`
- `npm test` *(fails: deno: not found)*
- `npm run setup:supabase` *(fails: The requested URL returned error: 503)*

------
https://chatgpt.com/codex/tasks/task_e_689eac934074832291072bb88b4fb0ed