### PR TITLE
feat: expand bot settings handlers

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1648,6 +1648,225 @@ export async function handleBotSettingsManagement(
   }
 }
 
+export async function handleConfigSessionSettings(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value")
+      .in("setting_key", ["session_timeout_minutes"]);
+    if (error) throw error;
+    let msg = "🕐 *Session Settings*\n\n";
+    (data || []).forEach((row) => {
+      msg += `• ${row.setting_key}: \`${row.setting_value}\`\n`;
+    });
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleConfigSessionSettings:", err);
+    await sendMessage(chatId, "❌ Error fetching session settings.");
+  }
+}
+
+export async function handleConfigFollowupSettings(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value")
+      .in("setting_key", ["follow_up_delay_minutes", "max_follow_ups"]);
+    if (error) throw error;
+    let msg = "📬 *Follow-up Settings*\n\n";
+    (data || []).forEach((row) => {
+      msg += `• ${row.setting_key}: \`${row.setting_value}\`\n`;
+    });
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleConfigFollowupSettings:", err);
+    await sendMessage(chatId, "❌ Error fetching follow-up settings.");
+  }
+}
+
+export async function handleToggleMaintenanceMode(
+  chatId: number,
+  userId: string,
+): Promise<void> {
+  try {
+    const { data } = await supabaseAdmin
+      .from("bot_settings")
+      .select("id, setting_value")
+      .eq("setting_key", "maintenance_mode")
+      .maybeSingle();
+    const current = (data?.setting_value || "false").toLowerCase() === "true";
+    await supabaseAdmin
+      .from("bot_settings")
+      .update({ setting_value: current ? "false" : "true" })
+      .eq("id", data?.id);
+    await logAdminAction(
+      userId,
+      "toggle_maintenance_mode",
+      `maintenance_mode=${current ? "false" : "true"}`,
+      "bot_settings",
+    );
+    const msg = `Maintenance mode ${current ? "disabled" : "enabled"}.`;
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleToggleMaintenanceMode:", err);
+    await sendMessage(chatId, "❌ Error toggling maintenance mode.");
+  }
+}
+
+export async function handleConfigAutoFeatures(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value")
+      .in("setting_key", ["auto_welcome"]);
+    if (error) throw error;
+    let msg = "🚀 *Auto Features*\n\n";
+    (data || []).forEach((row) => {
+      msg += `• ${row.setting_key}: \`${row.setting_value}\`\n`;
+    });
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleConfigAutoFeatures:", err);
+    await sendMessage(chatId, "❌ Error fetching auto feature settings.");
+  }
+}
+
+export async function handleConfigNotifications(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value")
+      .in("setting_key", ["admin_notifications"]);
+    if (error) throw error;
+    let msg = "🔔 *Notification Settings*\n\n";
+    (data || []).forEach((row) => {
+      msg += `• ${row.setting_key}: \`${row.setting_value}\`\n`;
+    });
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleConfigNotifications:", err);
+    await sendMessage(chatId, "❌ Error fetching notification settings.");
+  }
+}
+
+export async function handleConfigPerformance(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value")
+      .in("setting_key", ["auto_delete_delay_seconds"]);
+    if (error) throw error;
+    let msg = "⚡ *Performance Settings*\n\n";
+    (data || []).forEach((row) => {
+      msg += `• ${row.setting_key}: \`${row.setting_value}\`\n`;
+    });
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleConfigPerformance:", err);
+    await sendMessage(chatId, "❌ Error fetching performance settings.");
+  }
+}
+
+export async function handleAddNewSetting(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { count } = await supabaseAdmin
+      .from("bot_settings")
+      .select("id", { count: "exact", head: true });
+    const msg =
+      `➕ *Add New Setting*\n\nCurrent settings: ${count ?? 0}.\nSend new setting in the format \`key=value\`.`;
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleAddNewSetting:", err);
+    await sendMessage(chatId, "❌ Error preparing to add setting.");
+  }
+}
+
+export async function handleBackupBotSettings(
+  chatId: number,
+  userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_settings")
+      .select("setting_key, setting_value, is_active")
+      .order("setting_key", { ascending: true });
+    if (error) throw error;
+    const backup = JSON.stringify(data ?? [], null, 2);
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_settings" },
+      ]],
+    };
+    await sendMessage(
+      chatId,
+      `💾 *Bot Settings Backup*\n\n\`\`\`json\n${backup}\n\`\`\``,
+      keyboard,
+    );
+    await logAdminAction(
+      userId,
+      "backup_bot_settings",
+      "Exported bot settings",
+      "bot_settings",
+    );
+  } catch (err) {
+    console.error("Error in handleBackupBotSettings:", err);
+    await sendMessage(chatId, "❌ Error backing up settings.");
+  }
+}
+
 // Quick stats overview for all tables
 export async function handleTableStatsOverview(
   chatId: number,

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1005,6 +1005,30 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         case "manage_table_bot_settings":
           await handlers.handleBotSettingsManagement(chatId, userId);
           break;
+        case "config_session_settings":
+          await handlers.handleConfigSessionSettings(chatId, userId);
+          break;
+        case "config_followup_settings":
+          await handlers.handleConfigFollowupSettings(chatId, userId);
+          break;
+        case "toggle_maintenance_mode":
+          await handlers.handleToggleMaintenanceMode(chatId, userId);
+          break;
+        case "config_auto_features":
+          await handlers.handleConfigAutoFeatures(chatId, userId);
+          break;
+        case "config_notifications":
+          await handlers.handleConfigNotifications(chatId, userId);
+          break;
+        case "config_performance":
+          await handlers.handleConfigPerformance(chatId, userId);
+          break;
+        case "add_new_setting":
+          await handlers.handleAddNewSetting(chatId, userId);
+          break;
+        case "backup_bot_settings":
+          await handlers.handleBackupBotSettings(chatId, userId);
+          break;
         case "manage_table_daily_analytics":
           await handlers.handleDailyAnalyticsManagement(chatId, userId);
           break;


### PR DESCRIPTION
## Summary
- add handlers for session, follow-up, maintenance mode, auto feature, notification, performance, new setting, and backup actions
- register new callback cases for bot settings options

## Testing
- `npm test` (fails: deno not found)


------
https://chatgpt.com/codex/tasks/task_e_689eacb8840c832299e5229b94801407