### PR TITLE
Include security headers in miniapp 404 response

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -70,6 +70,6 @@ serve((req) => {
 
   return new Response(JSON.stringify({ ok: false, error: "Not Found" }), {
     status: 404,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...SECURITY_HEADERS },
   });
 });


### PR DESCRIPTION
## Summary
- apply SECURITY_HEADERS to 404 response in miniapp function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec2da266083229e0b175b3effdcd0