### PR TITLE
fix: remove invalid x-frame-options header

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -11,7 +11,8 @@ try {
 }
 
 const SECURITY_HEADERS = {
-  "x-frame-options": "ALLOWALL", // Allow embedding in Telegram
+  // Rely on the Content Security Policy's frame-ancestors directive for
+  // controlling embedding rather than the deprecated x-frame-options header.
   "content-security-policy":
     "default-src 'self' https://*.telegram.org https://telegram.org; " +
     "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +


### PR DESCRIPTION
## Summary
- remove deprecated `x-frame-options` header from miniapp function and rely on CSP `frame-ancestors` directive

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec3a17aac832298f2e81be9d7cd49