### PR TITLE
refactor: use async IIFE for admin check

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -34,7 +34,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         // Check admin status when user changes
         if (session?.user) {
-          setTimeout(async () => {
+          (async () => {
             try {
               const { data: profile } = await supabase
                 .from("profiles")
@@ -47,7 +47,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               console.error("Error checking admin status:", error);
               setIsAdmin(false);
             }
-          }, 0);
+          })();
         } else {
           setIsAdmin(false);
         }


### PR DESCRIPTION
## Summary
- replace setTimeout with async IIFE for profile fetch in useAuth

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecd562c388322bb4ecd59e9f81634