### PR TITLE
feat: guard miniapp index html load

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals, assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("serves 500 page when index.html fails to load", async () => {
+  const original = Deno.readFile;
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = () => {
+    throw new Error("boom");
+  };
+
+  const { handler } = await import("./index.ts");
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = original;
+
+  const res = await handler(new Request("http://example.com/"));
+  assertEquals(res.status, 500);
+  const text = await res.text();
+  assert(text.includes("Internal Server Error") || text.includes("500"));
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,9 +1,33 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { serveStatic } from "../_shared/static.ts";
 
-serve((req) =>
-  serveStatic(req, {
-    rootDir: new URL("./static/", import.meta.url),
-    spaRoots: ["/", "/miniapp"],
-  }),
-);
+const rootDir = new URL("./static/", import.meta.url);
+
+async function loadIndexHtml() {
+  await Deno.readFile(new URL("./index.html", rootDir));
+}
+
+const errorPage = new Response("<h1>Internal Server Error</h1>", {
+  status: 500,
+  headers: { "content-type": "text/html" },
+});
+
+let handler: (req: Request) => Response | Promise<Response>;
+
+try {
+  await loadIndexHtml();
+  handler = (req) =>
+    serveStatic(req, {
+      rootDir,
+      spaRoots: ["/", "/miniapp"],
+    });
+} catch {
+  console.error("[miniapp] failed to load index.html");
+  handler = () => errorPage;
+}
+
+if (import.meta.main) {
+  serve(handler);
+}
+
+export { handler };


### PR DESCRIPTION
## Summary
- wrap `loadIndexHtml()` in try/catch and serve a simple 500 page if it fails
- export handler and install a minimal 500 fallback for missing index
- add test covering index.html load failure fallback

## Testing
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A supabase/functions/miniapp/fallback.test.ts`
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check supabase/functions/_tests`


------
https://chatgpt.com/codex/tasks/task_e_689efd8b2dd48322828397011b40d412