### PR TITLE
Handle auto reply template query errors

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -2245,11 +2245,20 @@ export async function handleAutoReplyTemplatesManagement(
   _userId: string,
 ): Promise<void> {
   try {
-    const { data: templates, error: _err } = await supabaseAdmin
+    const { data: templates, error } = await supabaseAdmin
       .from("auto_reply_templates")
       .select("id,name,trigger_type,is_active,created_at")
       .order("created_at", { ascending: false })
       .limit(10);
+
+    if (error) {
+      console.error("Error fetching auto reply templates:", error);
+      await sendMessage(
+        chatId,
+        "❌ Error fetching auto reply templates. Please try again.",
+      );
+      return;
+    }
 
     const total = await supabaseAdmin
       .from("auto_reply_templates")


### PR DESCRIPTION
## Summary
- log failures when fetching auto reply templates and notify chat

## Testing
- `npm test` (fails: Connection refused in miniapp edge host routes)
- `npx eslint supabase/functions/telegram-bot/admin-handlers.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f03c7815c83229fdb3f87eb5e28a0