### PR TITLE
feat: add checkout flow and payment feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import NotFound from "./pages/NotFound";
 import { AdminDashboard } from "./components/admin/AdminDashboard";
 import { WelcomeMessage } from "./components/welcome/WelcomeMessage";
 import BotStatus from "./pages/BotStatus";
+import Checkout from "./pages/Checkout";
+import PaymentStatus from "./pages/PaymentStatus";
 
 const queryClient = new QueryClient();
 
@@ -30,6 +32,8 @@ const App = () => (
               <Route path="/education" element={<Education />} />
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/bot-status" element={<BotStatus />} />
+              <Route path="/checkout" element={<Checkout />} />
+              <Route path="/payment-status" element={<PaymentStatus />} />
               <Route path="/welcome" element={<WelcomeMessage />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/billing/CheckoutButton.tsx
+++ b/src/components/billing/CheckoutButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+interface CheckoutButtonProps {
+  plan: string;
+}
+
+export const CheckoutButton = ({ plan }: CheckoutButtonProps) => {
+  const navigate = useNavigate();
+
+  const handleCheckout = () => {
+    // In a real app, this would call a payment provider.
+    navigate(`/payment-status?status=success&plan=${encodeURIComponent(plan)}`);
+  };
+
+  return (
+    <Button onClick={handleCheckout} className="w-full">
+      Confirm and Pay
+    </Button>
+  );
+};
+
+export default CheckoutButton;
+

--- a/src/components/billing/PlanSummary.tsx
+++ b/src/components/billing/PlanSummary.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Check } from "lucide-react";
+
+interface PlanSummaryProps {
+  name: string;
+  price: string;
+  features: string[];
+}
+
+export const PlanSummary = ({ name, price, features }: PlanSummaryProps) => (
+  <Card>
+    <CardHeader>
+      <CardTitle>{name}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p className="mb-4 text-2xl font-bold">{price}</p>
+      <ul className="space-y-2">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-center">
+            <Check className="mr-2 h-4 w-4" />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </CardContent>
+  </Card>
+);
+
+export default PlanSummary;
+

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,0 +1,26 @@
+import PlanSummary from "@/components/billing/PlanSummary";
+import CheckoutButton from "@/components/billing/CheckoutButton";
+import { useSearchParams } from "react-router-dom";
+
+const Checkout = () => {
+  const [params] = useSearchParams();
+  const plan = params.get("plan") || "Pro";
+  const price = params.get("price") || "$10/mo";
+  const features = [
+    "Unlimited chats",
+    "Priority support",
+    "Early access to new features",
+  ];
+
+  return (
+    <div className="flex justify-center p-4">
+      <div className="w-full max-w-md space-y-4">
+        <PlanSummary name={plan} price={price} features={features} />
+        <CheckoutButton plan={plan} />
+      </div>
+    </div>
+  );
+};
+
+export default Checkout;
+

--- a/src/pages/PaymentStatus.tsx
+++ b/src/pages/PaymentStatus.tsx
@@ -1,0 +1,38 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, XCircle } from "lucide-react";
+import { Link, useSearchParams } from "react-router-dom";
+
+const PaymentStatus = () => {
+  const [params] = useSearchParams();
+  const status = params.get("status");
+  const isSuccess = status === "success";
+
+  return (
+    <div className="flex justify-center p-4">
+      <div className="w-full max-w-md space-y-4">
+        <Alert variant={isSuccess ? "default" : "destructive"}>
+          {isSuccess ? (
+            <CheckCircle2 className="h-4 w-4" />
+          ) : (
+            <XCircle className="h-4 w-4" />
+          )}
+          <AlertTitle>
+            {isSuccess ? "Payment Successful" : "Payment Failed"}
+          </AlertTitle>
+          <AlertDescription>
+            {isSuccess
+              ? "Thank you for your purchase! Your plan is now active."
+              : "Something went wrong with your payment. Please try again."}
+          </AlertDescription>
+        </Alert>
+        <Button asChild className="w-full">
+          <Link to="/">Return Home</Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentStatus;
+


### PR DESCRIPTION
## Summary
- add PlanSummary and CheckoutButton components
- create Checkout and PaymentStatus pages
- wire new pages into the router for plan confirmation and payment feedback

## Testing
- `npm test` *(fails: connection refused)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f503ca96c8322b9a9cdb3706fca10