### PR TITLE
feat: add plan confirmation and payment status pages

### DIFF
--- a/supabase/functions/miniapp/src/pages/Bank.tsx
+++ b/supabase/functions/miniapp/src/pages/Bank.tsx
@@ -36,6 +36,7 @@ export default function Bank() {
   const handleSubmit = async () => {
     if (file) {
       await api.uploadReceipt(file);
+      globalThis.location.href = "/status";
     }
   };
 

--- a/supabase/functions/miniapp/src/pages/Crypto.tsx
+++ b/supabase/functions/miniapp/src/pages/Crypto.tsx
@@ -20,7 +20,10 @@ export default function Crypto() {
   }, [network, api]);
 
   const handleSubmit = async () => {
-    if (txid) await api.submitTxid({ txid });
+    if (txid) {
+      await api.submitTxid({ txid });
+      globalThis.location.href = "/status";
+    }
   };
 
   useTelegramMainButton(!!txid, "Submit TXID", handleSubmit);

--- a/supabase/functions/miniapp/src/pages/Home.tsx
+++ b/supabase/functions/miniapp/src/pages/Home.tsx
@@ -21,6 +21,20 @@ export default function Home() {
 
         {/* Quick Actions */}
         <div className="grid gap-4 mb-8">
+          <Link to="/plan">
+            <Card className="bg-slate-800/50 border-slate-700 backdrop-blur hover:bg-slate-800/70 transition-colors">
+              <CardHeader className="text-center">
+                <div className="flex items-center justify-center gap-2">
+                  <Star className="h-5 w-5 text-primary" />
+                  <CardTitle className="text-white">Choose Plan</CardTitle>
+                </div>
+                <CardDescription className="text-slate-400">
+                  Confirm your VIP subscription
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+
           <Link to="/bank">
             <Card className="bg-slate-800/50 border-slate-700 backdrop-blur hover:bg-slate-800/70 transition-colors">
               <CardHeader className="text-center">
@@ -34,7 +48,7 @@ export default function Home() {
               </CardHeader>
             </Card>
           </Link>
-          
+
           <Link to="/crypto">
             <Card className="bg-slate-800/50 border-slate-700 backdrop-blur hover:bg-slate-800/70 transition-colors">
               <CardHeader className="text-center">
@@ -48,7 +62,7 @@ export default function Home() {
               </CardHeader>
             </Card>
           </Link>
-          
+
           <Link to="/me">
             <Card className="bg-slate-800/50 border-slate-700 backdrop-blur hover:bg-slate-800/70 transition-colors">
               <CardHeader className="text-center">

--- a/supabase/functions/miniapp/src/pages/Plan.tsx
+++ b/supabase/functions/miniapp/src/pages/Plan.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import TopBar from "../components/TopBar";
+import GlassPanel from "../components/GlassPanel";
+import PrimaryButton from "../components/PrimaryButton";
+import SecondaryButton from "../components/SecondaryButton";
+import { functionUrl } from "../lib/edge";
+import { useTelegramMainButton } from "../hooks/useTelegram";
+
+interface Plan {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+}
+
+interface BankAccount {
+  bank_name: string;
+  account_name: string;
+  account_number: string;
+  currency: string;
+}
+
+type Instructions =
+  | { type: "bank_transfer"; banks: BankAccount[] }
+  | { type: string; note: string };
+
+export default function Plan() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [method, setMethod] = useState<"bank_transfer" | "binance_pay" | "crypto">(
+    "bank_transfer",
+  );
+  const [instructions, setInstructions] = useState<Instructions | null>(null);
+  const [paymentId, setPaymentId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = functionUrl("plans");
+    if (!url) return;
+    fetch(url)
+      .then((res) => res.json())
+      .then((d) => setPlans(d.plans || []))
+      .catch(() => setPlans([]));
+  }, []);
+
+  const getTelegramId = () => {
+    try {
+      return String(
+        (globalThis as any).Telegram?.WebApp?.initDataUnsafe?.user?.id || "",
+      );
+    } catch {
+      return "";
+    }
+  };
+
+  const handleCheckout = async () => {
+    const url = functionUrl("checkout-init");
+    if (!url || !selected) return;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        telegram_id: getTelegramId(),
+        plan_id: selected,
+        method,
+      }),
+    });
+    const json = await res.json().catch(() => null);
+    if (json?.ok) {
+      setPaymentId(json.payment_id);
+      setInstructions(json.instructions as Instructions);
+    }
+  };
+
+  useTelegramMainButton(!!selected && !instructions, "Confirm", handleCheckout);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="Choose Plan" />
+      {!instructions && (
+        <div className="space-y-4">
+          {plans.map((p) => (
+            <GlassPanel
+              key={p.id}
+              className={`cursor-pointer${selected === p.id ? " ring-1 ring-primary" : ""}`}
+              onClick={() => setSelected(p.id)}
+            >
+              <div className="flex items-center justify-between">
+                <span>{p.name}</span>
+                <span className="text-sm">
+                  ${p.price} {p.currency}
+                </span>
+              </div>
+            </GlassPanel>
+          ))}
+          <div className="flex gap-2">
+            <SecondaryButton
+              label="Bank"
+              onClick={() => setMethod("bank_transfer")}
+              className={method === "bank_transfer" ? "opacity-100" : "opacity-60"}
+            />
+            <SecondaryButton
+              label="Binance Pay"
+              onClick={() => setMethod("binance_pay")}
+              className={method === "binance_pay" ? "opacity-100" : "opacity-60"}
+            />
+            <SecondaryButton
+              label="Crypto"
+              onClick={() => setMethod("crypto")}
+              className={method === "crypto" ? "opacity-100" : "opacity-60"}
+            />
+          </div>
+          <PrimaryButton
+            label="Confirm"
+            onClick={handleCheckout}
+            disabled={!selected || !!instructions}
+            className="mt-4"
+          />
+        </div>
+      )}
+      {instructions && (
+        <div className="space-y-4">
+          {instructions.type === "bank_transfer" ? (
+            <div className="space-y-2">
+              {instructions.banks.map((b, idx) => (
+                <GlassPanel key={idx} className="text-sm">
+                  <p className="font-medium">{b.bank_name}</p>
+                  <p>Account Name: {b.account_name}</p>
+                  <p>Account Number: {b.account_number}</p>
+                  <p>Currency: {b.currency}</p>
+                </GlassPanel>
+              ))}
+            </div>
+          ) : (
+            <GlassPanel className="text-sm">{instructions.note}</GlassPanel>
+          )}
+          {paymentId && (
+            <PrimaryButton
+              label="View Status"
+              onClick={() => {
+                globalThis.location.href = `/status?payment_id=${paymentId}`;
+              }}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/supabase/functions/miniapp/src/pages/Status.tsx
+++ b/supabase/functions/miniapp/src/pages/Status.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import TopBar from "../components/TopBar";
+import GlassRow from "../components/GlassRow";
+import StatusPill from "../components/StatusPill";
+import { useApi } from "../hooks/useApi";
+
+interface Receipt {
+  id: string;
+  amount: number;
+  status: string;
+  created_at: string;
+}
+
+export default function Status() {
+  const api = useApi();
+  const [search] = useSearchParams();
+  const paymentId = search.get("payment_id");
+  const [receipt, setReceipt] = useState<Receipt | null>(null);
+
+  useEffect(() => {
+    api.getReceipts(5).then((res: any) => {
+      const items = Array.isArray(res) ? res : res.items || [];
+      const found = items.find((r: Receipt) => r.id === paymentId) || items[0];
+      setReceipt(found || null);
+    });
+  }, [api, paymentId]);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="Payment Status" />
+      {receipt ? (
+        <GlassRow
+          left={<span className="text-sm">{receipt.id.slice(0, 6)}…</span>}
+          right={<StatusPill status={receipt.status as any} />}
+        />
+      ) : (
+        <p className="p-4 text-sm">No payment information available.</p>
+      )}
+    </div>
+  );
+}
+

--- a/supabase/functions/miniapp/src/router.tsx
+++ b/supabase/functions/miniapp/src/router.tsx
@@ -4,6 +4,8 @@ import Bank from "./pages/Bank";
 import Crypto from "./pages/Crypto";
 import Me from "./pages/Me";
 import Admin from "./pages/Admin";
+import Plan from "./pages/Plan";
+import Status from "./pages/Status";
 
 export default function AppRouter() {
   return (
@@ -11,6 +13,8 @@ export default function AppRouter() {
       <Route path="/" element={<Home />} />
       <Route path="/bank" element={<Bank />} />
       <Route path="/crypto" element={<Crypto />} />
+      <Route path="/plan" element={<Plan />} />
+      <Route path="/status" element={<Status />} />
       <Route path="/me" element={<Me />} />
       <Route path="/admin" element={<Admin />} />
     </Routes>


### PR DESCRIPTION
## Summary
- add plan confirmation flow in telegram bot and expose latest payment status
- introduce Plan and Status pages in mini app with checkout handling
- redirect deposit flows to status page and expose plan link on home screen

## Testing
- `npm test` *(fails: Connection refused in miniapp edge host routes)*

------
https://chatgpt.com/codex/tasks/task_e_689f52b55d6c83228a6ecab0dce80125