### PR TITLE
Notify when checkout disabled

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -221,8 +221,14 @@ function hasValidMiniAppUrl(): boolean {
 }
 
 export async function sendMiniAppLink(chatId: number) {
-  if (!(await getFlag("mini_app_enabled"))) return;
   if (!BOT_TOKEN) return;
+  if (!(await getFlag("mini_app_enabled"))) {
+    await sendMessage(
+      chatId,
+      "Checkout is currently unavailable. Please try again later.",
+    );
+    return;
+  }
 
   const rawUrl = optionalEnv("MINI_APP_URL") || "";
   const short = optionalEnv("MINI_APP_SHORT_NAME") || "";

--- a/tests/feature-blocks.test.ts
+++ b/tests/feature-blocks.test.ts
@@ -29,15 +29,19 @@ registerTest("mini app flag blocks link", async () => {
   const { sendMiniAppLink } = await import(
     "../supabase/functions/telegram-bot/index.ts"
   );
-  let called = false;
+  let text = "";
   const orig = globalThis.fetch;
-  globalThis.fetch = async () => {
-    called = true;
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(init?.body ?? "{}");
+    text = body.text;
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   };
   try {
     await sendMiniAppLink(123);
-    assertEquals(called, false);
+    assertEquals(
+      text,
+      "Checkout is currently unavailable. Please try again later.",
+    );
   } finally {
     globalThis.fetch = orig;
     delete (globalThis as any).__TEST_ENV__;


### PR DESCRIPTION
## Summary
- Inform users when the mini app checkout feature is disabled
- Adjust mini app flag test to validate the new notification

## Testing
- `npm test` *(fails: miniapp edge host routes connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f5563c448832280537929fee067c6