### PR TITLE
Add /account alias and update command help

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -64,7 +64,7 @@ Use the buttons below or type /packages, /vip or /help to get started.`,
 
 Available commands:
 /start - Main menu
-/dashboard - View account dashboard
+/dashboard or /account - View account dashboard
 /packages - View VIP packages
 /vip - VIP benefits
 /help - Show help
@@ -92,7 +92,7 @@ We typically respond within 2-4 hours.`,
 
 Available commands:
 /start - Main menu
-/dashboard - View account dashboard
+/dashboard or /account - View account dashboard
 /packages - View VIP packages
 /vip - VIP benefits
 /help - Show this help
@@ -274,9 +274,11 @@ export async function getAllBotSettings(): Promise<Record<string, string>> {
     }
 
     const settings: Record<string, string> = {};
-    (data ?? []).forEach((s: { setting_key: string; setting_value: string }) => {
-      settings[s.setting_key] = s.setting_value;
-    });
+    (data ?? []).forEach(
+      (s: { setting_key: string; setting_value: string }) => {
+        settings[s.setting_key] = s.setting_value;
+      },
+    );
     return settings;
   } catch (error) {
     console.error("Exception in getAllBotSettings:", error);
@@ -289,10 +291,10 @@ export async function resetBotSettings(
   adminId: string,
 ): Promise<boolean> {
   try {
-  const rows = Object.entries(defaultSettings).map(([key, value]) => ({
-    setting_key: key,
-    setting_value: value,
-  }));
+    const rows = Object.entries(defaultSettings).map(([key, value]) => ({
+      setting_key: key,
+      setting_value: value,
+    }));
 
     const { error } = await supabaseAdmin
       .from("bot_settings")
@@ -507,9 +509,9 @@ export async function processPlanEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-        .update({
-          price: price,
-        })
+          .update({
+            price: price,
+          })
           .eq("id", planId);
 
         if (error) {
@@ -545,9 +547,9 @@ export async function processPlanEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-        .update({
-          name: name,
-        })
+          .update({
+            name: name,
+          })
           .eq("id", planId);
 
         if (error) {
@@ -594,10 +596,10 @@ export async function processPlanEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-        .update({
-          duration_months: durationMonths,
-          is_lifetime: isLifetime,
-        })
+          .update({
+            duration_months: durationMonths,
+            is_lifetime: isLifetime,
+          })
           .eq("id", planId);
 
         if (error) {
@@ -654,9 +656,9 @@ export async function processPlanEditInput(
 
         const { error } = await supabaseAdmin
           .from("subscription_plans")
-        .update({
-          features: updatedFeatures,
-        })
+          .update({
+            features: updatedFeatures,
+          })
           .eq("id", planId);
 
         if (error) {

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -283,8 +283,7 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
 async function menuView(
   section: "home" | "plans" | "status" | "support",
   chatId?: number,
-): Promise<{ text: string; extra: Record<string, unknown> }>
-{
+): Promise<{ text: string; extra: Record<string, unknown> }> {
   const base = {
     reply_markup: {
       inline_keyboard: [
@@ -346,7 +345,10 @@ async function menuView(
     }
     case "support": {
       const msg = await getBotContent("support_message");
-      return { text: msg ?? "Support information is unavailable.", extra: base };
+      return {
+        text: msg ?? "Support information is unavailable.",
+        extra: base,
+      };
     }
     case "home":
     default:
@@ -731,15 +733,17 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
             .from("promotions")
             .select("code,discount_type,discount_value")
             .eq("is_active", true)
-            .or(`valid_until.is.null,valid_until.gt.${new Date().toISOString()}`)
+            .or(
+              `valid_until.is.null,valid_until.gt.${new Date().toISOString()}`,
+            )
             .limit(5);
           const lines = promos?.length
             ? promos.map((p: Promotion, i: number) => {
-                const discount = p.discount_type === "percentage"
-                  ? `${p.discount_value}%`
-                  : `$${p.discount_value}`;
-                return `${i + 1}. ${p.code} - ${discount}`;
-              }).join("\n")
+              const discount = p.discount_type === "percentage"
+                ? `${p.discount_value}%`
+                : `$${p.discount_value}`;
+              return `${i + 1}. ${p.code} - ${discount}`;
+            }).join("\n")
             : "No active promotions.";
           await notifyUser(
             chatId,
@@ -912,6 +916,7 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
         await handleAdminDashboard(chatId, userId);
         break;
       }
+      case "/account":
       case "/status": {
         const supa = await getSupabase();
         if (supa) {
@@ -1105,7 +1110,9 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
   }
 }
 
-export async function startReceiptPipeline(update: TelegramUpdate): Promise<void> {
+export async function startReceiptPipeline(
+  update: TelegramUpdate,
+): Promise<void> {
   try {
     const chatId = update.message!.chat.id;
     if (!(await getFlag("vip_sync_enabled"))) {


### PR DESCRIPTION
## Summary
- handle `/account` command by reusing existing status logic
- mention `/account` in default help and welcome messages

## Testing
- `deno fmt supabase/functions/telegram-bot/index.ts supabase/functions/telegram-bot/database-utils.ts`
- `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts` *(failed: JSR package manifest for '@supabase/supabase-js' failed to load)*
- `deno test -A --unsafely-ignore-certificate-errors=registry.npmjs.org,deno.land` *(failed: could not find constraint '@types/node')*

------
https://chatgpt.com/codex/tasks/task_e_689f5a3ef954832294e34f585d3de9da