### PR TITLE
feat: add interactive package checkout

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -233,12 +233,22 @@ async function handleHelpCommand(chatId: number): Promise<void> {
 
 #### `/packages`
 
-Show available VIP packages and subscription options
+Show available VIP packages and subscription options with interactive buttons
+that let the user start the checkout flow.
 
 ```typescript
 async function handlePackagesCommand(chatId: number): Promise<void> {
-  const vipPackages = await getFormattedVipPackages();
-  await sendMessage(chatId, vipPackages);
+  const msg = await getFormattedVipPackages();
+  const pkgs = await getVipPackages();
+  const inline_keyboard = pkgs.map((pkg) => [{
+    text: pkg.name,
+    callback_data: "buy:" + pkg.id,
+  }]);
+  inline_keyboard.push([{ text: "Back", callback_data: "menu:home" }]);
+  await sendMessage(chatId, msg, {
+    parse_mode: "Markdown",
+    reply_markup: { inline_keyboard },
+  });
 }
 ```
 

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -717,7 +717,16 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
       }
       case "/packages": {
         const msg = await getFormattedVipPackages();
-        await notifyUser(chatId, msg, { parse_mode: "Markdown" });
+        const pkgs = await getVipPackages();
+        const inline_keyboard = pkgs.map((pkg) => [{
+          text: pkg.name,
+          callback_data: "buy:" + pkg.id,
+        }]);
+        inline_keyboard.push([{ text: "Back", callback_data: "menu:home" }]);
+        await notifyUser(chatId, msg, {
+          reply_markup: { inline_keyboard },
+          parse_mode: "Markdown",
+        });
         break;
       }
       case "/promo": {


### PR DESCRIPTION
## Summary
- add buy buttons to /packages command for inline checkout
- document interactive package selection and checkout flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f952a09688322979901c95de8e34e