### PR TITLE
Handle missing mini app link in pay callback

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -963,7 +963,15 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
     if (data.startsWith("pay:")) {
       await notifyUser(chatId, "Opening checkout...");
       const url = await sendMiniAppLink(chatId);
-      await answerCallbackQuery(cb.id, url ? { url } : {});
+      if (!url) {
+        await notifyUser(
+          chatId,
+          "Checkout unavailable—please try again later or contact support",
+        );
+        await answerCallbackQuery(cb.id);
+      } else {
+        await answerCallbackQuery(cb.id, { url });
+      }
       return;
     }
     // Acknowledge other callbacks promptly to avoid client retries


### PR DESCRIPTION
## Summary
- capture checkout link result in pay callback
- notify user when checkout URL is unavailable and acknowledge without URL
- only include URL in callback acknowledgement when available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9741493c8322bb6189f1a6834d73