### PR TITLE
chore: sync miniapp static before deploy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     "miniapp:build": "deno run -A scripts/build-miniapp.ts",
     "miniapp:dev": "cd supabase/functions/miniapp && npm run dev",
     "miniapp:check": "deno run -A scripts/miniapp-health-check.ts",
-    "miniapp:deploy": "deno task miniapp:build && npx supabase functions deploy miniapp"
+    "miniapp:deploy": "deno task miniapp:build && node scripts/sync-miniapp-static.mjs && npx supabase functions deploy miniapp"
   },
   "nodeModulesDir": true,
   "compilerOptions": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,7 +15,7 @@
     "linkage:check": "deno run -A scripts/check-linkage.ts",
     "serve:linkage-audit": "supabase functions serve --no-verify-jwt linkage-audit",
     "guard:env": "deno run -A scripts/guard-env-usage.ts",
-    "miniapp:deploy": "npx supabase functions deploy miniapp",
+    "miniapp:deploy": "deno task miniapp:build && node scripts/sync-miniapp-static.mjs && npx supabase functions deploy miniapp",
     "miniapp:check": "deno run -A scripts/miniapp-domain-check.ts",
     "edge:call": "deno run -A scripts/call-edge.ts",
     "edge:deploy:verify": "npx supabase functions deploy verify-initdata",


### PR DESCRIPTION
## Summary
- run `scripts/sync-miniapp-static.mjs` after miniapp build and before deploying Supabase functions
- ensure static bundle is included in deploy config

## Testing
- `npm run lint`
- `npm test` *(fails: handler is not a function / export not provided)*

------
https://chatgpt.com/codex/tasks/task_e_689fe64ef6588322a161576f4c30432c