### PR TITLE
feat: log miniapp index.html read errors

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -1,17 +1,15 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
 Deno.test("returns 404 when index.html fails to load", async () => {
-  const original = Deno.readTextFile;
-  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
-    () => {
-      throw new Error("boom");
-    };
+  const original = Deno.readFile;
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = () => {
+    throw new Deno.errors.NotFound("boom");
+  };
 
   const { handler } = await import("./index.ts");
-  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
-    original;
 
   const res = await handler(new Request("http://example.com/"));
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = original;
   assertEquals(res.status, 404);
-  assertEquals(await res.text(), "Index file not found");
+  assert((await res.text()).includes("Static <code>index.html</code> not found"));
 });


### PR DESCRIPTION
## Summary
- log when miniapp index.html fails to load and advise running sync script
- return 404 for missing index.html and 500 for other read failures
- export handler and guard serve for easier testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe8a6b61c8322882319f62e59600f