### PR TITLE
feat(bot): fetch packages in parallel

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -298,8 +298,10 @@ async function menuView(
 
   switch (section) {
     case "plans": {
-      const msg = await getFormattedVipPackages();
-      const pkgs = await getVipPackages();
+      const [msg, pkgs] = await Promise.all([
+        getFormattedVipPackages(),
+        getVipPackages(),
+      ]);
       const inline_keyboard = pkgs.map((pkg) => [{
         text: pkg.name,
         callback_data: "buy:" + pkg.id,
@@ -719,8 +721,10 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
         break;
       }
       case "/packages": {
-        const msg = await getFormattedVipPackages();
-        const pkgs = await getVipPackages();
+        const [msg, pkgs] = await Promise.all([
+          getFormattedVipPackages(),
+          getVipPackages(),
+        ]);
         const inline_keyboard = pkgs.map((pkg) => [{
           text: pkg.name,
           callback_data: "buy:" + pkg.id,


### PR DESCRIPTION
## Summary
- fetch VIP package info concurrently for menu and `/packages` command

## Testing
- `npm test` *(fails: handler is not a function; missing export from miniapp)*
- `SUPABASE_URL=http://local SUPABASE_SERVICE_ROLE_KEY=svc SUPABASE_ANON_KEY=anon TELEGRAM_BOT_TOKEN=testtoken TELEGRAM_WEBHOOK_SECRET=testsecret deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check tests/start-handler.test.ts tests/telegram-bot-direct-photo.test.ts tests/telegram-bot-security.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ff03d7f248322930dcecb467f63e9