### PR TITLE
Highlight active section in Telegram bot main menu

### DIFF
--- a/supabase/functions/telegram-bot/menu.ts
+++ b/supabase/functions/telegram-bot/menu.ts
@@ -1,0 +1,16 @@
+export type MenuSection = "home" | "plans" | "status" | "support";
+
+export function buildMainMenu(section: MenuSection) {
+  const mk = (sect: MenuSection, label: string) => [{
+    text: `${sect === section ? "✅ " : ""}${label}`,
+    callback_data: `menu:${sect}`,
+  }];
+  return {
+    inline_keyboard: [
+      mk("home", "Home"),
+      mk("plans", "Packages"),
+      mk("status", "Status"),
+      mk("support", "Support"),
+    ],
+  };
+}

--- a/tests/main-menu.test.ts
+++ b/tests/main-menu.test.ts
@@ -1,0 +1,12 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { buildMainMenu } from "../supabase/functions/telegram-bot/menu.ts";
+
+Deno.test("buildMainMenu highlights active section", () => {
+  const home = buildMainMenu("home");
+  assertEquals(home.inline_keyboard[0][0].text, "✅ Home");
+  assertEquals(home.inline_keyboard[1][0].text, "Packages");
+
+  const plans = buildMainMenu("plans");
+  assertEquals(plans.inline_keyboard[0][0].text, "Home");
+  assertEquals(plans.inline_keyboard[1][0].text, "✅ Packages");
+});

--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -61,7 +61,7 @@ Deno.test("/start shows menu buttons for new users", async () => {
     assertEquals(first.text, "Welcome new user");
     const second = JSON.parse(calls[1].body);
     assertEquals(second.text, "Welcome! Choose an option:");
-    assertEquals(second.reply_markup.inline_keyboard[0][0].text, "Home");
+    assertEquals(second.reply_markup.inline_keyboard[0][0].text, "✅ Home");
   } finally {
     globalThis.fetch = originalFetch;
     cleanup();


### PR DESCRIPTION
## Summary
- add `buildMainMenu` helper to construct main menu with current section highlighted
- use helper throughout Telegram bot menu handling and callbacks
- cover menu highlighting with new and updated tests

## Testing
- `npm test` *(fails: miniapp-edge-host-routing.test.ts, miniapp/fallback.test.ts)*
- `SUPABASE_URL=http://local SUPABASE_SERVICE_ROLE_KEY=svc SUPABASE_ANON_KEY=anon TELEGRAM_BOT_TOKEN=testtoken TELEGRAM_WEBHOOK_SECRET=testsecret deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check tests/main-menu.test.ts tests/start-handler.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ff23ff98c8322bad8c6c61d0255d6