### PR TITLE
feat: export miniapp handler

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -18,7 +18,10 @@ Deno.test("returns fallback HTML when index.html fails to load", async () => {
     const res = await handler(new Request("http://example.com/"));
     assertEquals(res.status, 200);
     const body = await res.text();
-    assertStringIncludes(body, "Static `index.html` not found in bundle");
+    assertStringIncludes(
+      body,
+      "Static <code>index.html</code> not found in bundle",
+    );
   } finally {
     (Deno as unknown as { readFile: typeof Deno.readFile }).readFile =
       original;

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -68,7 +68,7 @@ function mime(p: string) {
   return "application/octet-stream";
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "miniapp", ts: new Date().toISOString() });
@@ -77,7 +77,11 @@ serve(async (req) => {
   if (req.method !== "GET") return mna();
 
   // Only serve these routes
-  if (url.pathname === "/" || url.pathname === "/miniapp" || url.pathname === "/miniapp/") {
+  if (
+    url.pathname === "/" ||
+    url.pathname === "/miniapp" ||
+    url.pathname === "/miniapp/"
+  ) {
     return await indexHtml();
   }
   if (url.pathname.startsWith("/assets/")) {
@@ -85,5 +89,9 @@ serve(async (req) => {
     return await readStatic(rel, mime(rel));
   }
   return nf("Not Found");
-});
+}
+
+if (import.meta.main) {
+  serve(handler);
+}
 


### PR DESCRIPTION
## Summary
- refactor miniapp function to export a `handler` and only start the server when run directly
- adjust fallback test to match static HTML message

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff8b7fb848322b5b06112e0208798