### PR TITLE
feat: add sync audit endpoint

### DIFF
--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -1,178 +1,181 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "../_shared/client.ts";
-import { unauth, ok } from "../_shared/http.ts";
-import { expectedSecret, readDbWebhookSecret } from "../_shared/telegram_secret.ts";
+// supabase/functions/sync-audit/index.ts
+// Audits bot/miniapp linkage and optionally fixes drift.
 
-const need = (k: string) =>
-  Deno.env.get(k) || (() => {
-    throw new Error(`Missing env ${k}`);
-  })();
+import { optionalEnv } from "../_shared/env.ts";
+import { ok, unauth, nf, mna, oops } from "../_shared/http.ts";
+import { expectedSecret } from "../_shared/telegram_secret.ts";
 
-function projectRef(): string {
-  const u = need("SUPABASE_URL");
+interface TelegramResponse {
+  ok: boolean;
+  result?: Record<string, unknown>;
+}
+
+async function tg(token: string, method: string, body?: unknown): Promise<
+  TelegramResponse
+> {
   try {
-    return new URL(u).hostname.split(".")[0];
-  } catch {
-    return need("SUPABASE_PROJECT_ID");
-  }
-}
-function normUrl(u: string) {
-  return u.endsWith("/") ? u : (u + "/");
-}
-
-function genHex(n = 24) {
-  const b = new Uint8Array(n);
-  crypto.getRandomValues(b);
-  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
-}
-
-interface SupaUpsert {
-  from: (table: string) => {
-    upsert: (
-      values: Record<string, unknown>,
-      options: { onConflict: string },
-    ) => Promise<{ error?: { message: string } }>; 
-  };
-}
-
-async function upsertDbSecret(supa: SupaUpsert, val: string) {
-  const { error } = await supa.from("bot_settings").upsert({
-    setting_key: "TELEGRAM_WEBHOOK_SECRET",
-    setting_value: val,
-  }, { onConflict: "setting_key" });
-  if (error) throw new Error("upsert bot_settings failed: " + error.message);
-}
-
-async function tg(token: string, method: string, body?: unknown) {
-  const r = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  const j = await r.json().catch(() => ({}));
-  return { status: r.status, json: j };
-}
-
-serve(async (req) => {
-  const url = new URL(req.url);
-  if (req.method === "GET" && url.pathname.endsWith("/version")) {
-    return ok({ name: "sync-audit", ts: new Date().toISOString() });
-  }
-  if (req.method !== "POST" && req.method !== "GET") {
-    return new Response("Method Not Allowed", { status: 405 });
-  }
-  const admin = Deno.env.get("ADMIN_API_SECRET") || "";
-  const auth = req.headers.get("authorization") || "";
-  const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : "";
-  const alt = req.headers.get("x-admin-secret") || "";
-  if (!admin || (bearer !== admin && alt !== admin)) {
-    return unauth();
-  }
-  const ref = projectRef();
-  const expectedWebhook = `https://${ref}.functions.supabase.co/telegram-bot`;
-  const expectedMini = normUrl(
-    Deno.env.get("MINI_APP_URL") ||
-      `https://${ref}.functions.supabase.co/miniapp/`,
-  );
-
-  const supa = createClient();
-  const token = need("TELEGRAM_BOT_TOKEN");
-
-  const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};
-  const fix = Boolean(body?.fix);
-
-  // 1) Telegram state
-  const webhookInfo = await tg(token, "getWebhookInfo");
-  const chatMenu = await tg(token, "getChatMenuButton");
-
-  const currentWebhook = webhookInfo.json?.result?.url || null;
-  const currentMenuUrl = chatMenu.json?.result?.menu_button?.web_app?.url ||
-    null;
-
-  // 2) Function reachability
-  async function fetchJSON(u: string) {
-    try {
-      const r = await fetch(u);
-      const j = await r.json();
-      return { ok: r.ok, j };
-    } catch {
-      return { ok: false, j: null };
-    }
-  }
-  const botVer = await fetchJSON(`${expectedWebhook}/version`);
-  const miniVer = await fetchJSON(`${expectedMini}version`);
-
-  // 3) Secret presence (ENV/DB)
-  const envSecret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || null;
-  let dbSecret = await readDbWebhookSecret();
-  
-  // 4) Compute mismatches
-  const mismatches: string[] = [];
-  if (currentWebhook !== expectedWebhook) mismatches.push("webhook_url");
-  if (currentMenuUrl !== expectedMini) mismatches.push("chat_menu_url");
-  if (!botVer.ok) mismatches.push("bot_unreachable");
-  if (!miniVer.ok) mismatches.push("mini_unreachable");
-  const secret = dbSecret || envSecret;
-  if (!secret) mismatches.push("webhook_secret_missing");
-
-  // 5) Optional fixes
-  const actions: Array<Record<string, unknown>> = [];
-  if (fix) {
-    // Ensure we have a secret
-    if (!secret) {
-      dbSecret = genHex(24);
-      await upsertDbSecret(supa, dbSecret);
-      actions.push({ set: "db_secret" });
-    }
-    const secretVal = await expectedSecret();
-
-    // Reapply webhook if needed
-    if (currentWebhook !== expectedWebhook) {
-      const set = await tg(token, "setWebhook", {
-        url: expectedWebhook,
-        secret_token: secretVal!,
-        allowed_updates: ["message", "callback_query"],
-        drop_pending_updates: false,
-      });
-      actions.push({ setWebhook: set.json });
-    }
-
-    // Reset chat menu button if needed (add cache-busting v if requested)
-    const ver = body?.version || String(Date.now());
-      const targetMenu = body?.no_version
-      ? expectedMini
-      : `${expectedMini}?v=${ver}`;
-    if (currentMenuUrl !== targetMenu) {
-      const set = await tg(token, "setChatMenuButton", {
-        menu_button: {
-          type: "web_app",
-          text: "Join",
-          web_app: { url: targetMenu },
-        },
-      });
-      actions.push({ setChatMenuButton: set.json, url: targetMenu });
-    }
-  }
-
-  const ok = mismatches.length === 0;
-
-  return new Response(
-    JSON.stringify(
+    const r = await fetch(
+      `https://api.telegram.org/bot${token}/${method}`,
       {
-        ok,
-        expected: { webhook: expectedWebhook, miniapp: expectedMini },
-        actual: { webhook: currentWebhook, chat_menu: currentMenuUrl },
-        reachability: { bot: botVer.ok, mini: miniVer.ok },
-        secret: { env: !!envSecret, db: !!dbSecret },
-        mismatches,
-        actions,
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
       },
-      null,
-      2,
-    ),
-    {
-      headers: { "content-type": "application/json" },
-      status: ok ? 200 : (fix ? 207 : 200),
-    },
-  );
-});
+    );
+    return await r.json();
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function handler(req: Request): Promise<Response> {
+  try {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    // Public version endpoint
+    if (req.method === "GET" && path === "/version") {
+      return ok({ name: "sync-audit", ts: new Date().toISOString() });
+    }
+
+    // Auth guard
+    const admin = optionalEnv("ADMIN_API_SECRET");
+    if (path !== "/version") {
+      if (!admin) return unauth();
+      const header = req.headers.get("x-admin-secret");
+      if (!header || header !== admin) return unauth();
+    }
+
+    // Only accept POST /
+    if (req.method === "POST" && path === "/") {
+      const body = await req.json().catch(() => ({}));
+      const fix = Boolean(body?.fix);
+
+      // --- Step 1: collect env secrets ---
+      const supabaseUrl = optionalEnv("SUPABASE_URL");
+      const serviceKey = optionalEnv("SUPABASE_SERVICE_ROLE_KEY");
+      const botToken = optionalEnv("TELEGRAM_BOT_TOKEN");
+      const miniUrlRaw = optionalEnv("MINI_APP_URL");
+      const miniShort = optionalEnv("MINI_APP_SHORT_NAME");
+      const webhookSecret = await expectedSecret();
+
+      const secrets = {
+        SUPABASE_URL: !!supabaseUrl,
+        SUPABASE_SERVICE_ROLE_KEY: !!serviceKey,
+        TELEGRAM_BOT_TOKEN: !!botToken,
+        TELEGRAM_WEBHOOK_SECRET: !!webhookSecret,
+        MINI_APP_URL: !!miniUrlRaw,
+        MINI_APP_SHORT_NAME: !!miniShort,
+      };
+      const missing = Object.entries(secrets)
+        .filter(([, v]) => !v)
+        .map(([k]) => k);
+
+      // --- Step 2: derive expected endpoints ---
+      const functionsBase = `${url.protocol}//${url.host}`;
+      const expectedWebhook = `${functionsBase}/telegram-bot`;
+
+      // --- Step 3: ping related endpoints ---
+      const [botVer, miniVer, miniHead] = await Promise.all([
+        fetch(`${functionsBase}/telegram-bot/version`).catch(() => null),
+        fetch(`${functionsBase}/miniapp/version`).catch(() => null),
+        fetch(`${functionsBase}/miniapp`, { method: "HEAD" }).catch(() => null),
+      ]);
+
+      const endpoints = {
+        telegramBotVersion: botVer?.ok ?? false,
+        miniappVersion: miniVer?.ok ?? false,
+        miniappHead: miniHead?.ok ?? false,
+      };
+
+      // --- Step 4: inspect Telegram webhook ---
+      let webhookActual: string | null = null;
+      let webhookFixed = false;
+      let webhookSecretOk = true;
+      if (botToken) {
+        const info = await tg(botToken, "getWebhookInfo");
+        webhookActual = info?.result?.url as string | null ?? null;
+        const currentSecret = info?.result?.secret_token as string | null ?? null;
+        webhookSecretOk = !webhookSecret || currentSecret === webhookSecret;
+        const mismatch =
+          webhookActual !== expectedWebhook || !webhookSecretOk;
+        if (mismatch && fix && webhookSecret) {
+          const set = await tg(botToken, "setWebhook", {
+            url: expectedWebhook,
+            secret_token: webhookSecret,
+            allowed_updates: ["message", "callback_query"],
+          });
+          webhookFixed = !!set?.ok;
+          if (webhookFixed) {
+            webhookActual = expectedWebhook;
+            webhookSecretOk = true;
+          }
+        }
+      }
+
+      // --- Step 5: determine mini-app URL and menu button ---
+      let miniExpected: string | null = null;
+      if (miniUrlRaw) {
+        miniExpected = miniUrlRaw.endsWith("/") ? miniUrlRaw : `${miniUrlRaw}/`;
+      } else if (miniShort && botToken) {
+        const me = await tg(botToken, "getMe");
+        const username = me?.result?.username as string | undefined;
+        if (username) {
+          miniExpected = `https://t.me/${username}/${miniShort}`;
+        }
+      }
+
+      let menuActual: string | null = null;
+      let menuFixed = false;
+      if (botToken) {
+        const menu = await tg(botToken, "getChatMenuButton");
+        menuActual =
+          menu?.result?.menu_button?.web_app?.url as string | null ?? null;
+        const menuMismatch = miniExpected && menuActual !== miniExpected;
+        if (menuMismatch && fix && miniExpected) {
+          const set = await tg(botToken, "setChatMenuButton", {
+            menu_button: {
+              type: "web_app",
+              text: "Join",
+              web_app: { url: miniExpected },
+            },
+          });
+          menuFixed = !!set?.ok;
+          if (menuFixed) menuActual = miniExpected;
+        }
+      }
+
+      // --- Summaries ---
+      const notes: string[] = [...missing];
+      if (!endpoints.telegramBotVersion) notes.push("telegram-bot/version");
+      if (!endpoints.miniappVersion) notes.push("miniapp/version");
+      if (!endpoints.miniappHead) notes.push("miniapp_head");
+      if (webhookActual !== expectedWebhook) notes.push("webhook_url");
+      if (!webhookSecretOk) notes.push("webhook_secret");
+      if (miniExpected && menuActual !== miniExpected) notes.push("menu_url");
+
+      const okAll = notes.length === 0;
+
+      return ok({
+        ok: okAll,
+        secrets,
+        endpoints,
+        telegram: {
+          webhook: { expected: expectedWebhook, actual: webhookActual, fixed: webhookFixed },
+          menu: { expected: miniExpected, actual: menuActual, fixed: menuFixed },
+        },
+        notes,
+        version: { name: "sync-audit", ts: new Date().toISOString() },
+      });
+    }
+
+    // unmatched routes
+    if (req.method === "GET") return nf();
+    return mna();
+  } catch (e) {
+    return oops("sync-audit error", e instanceof Error ? e.message : String(e));
+  }
+}
+
+Deno.serve(handler);
+


### PR DESCRIPTION
## Summary
- add sync-audit function handler with admin-protected POST endpoint
- audit Supabase and Telegram configuration and optionally fix drift
- expose version route and call Deno.serve

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ffbabdff08322a5baa8d6e5ee073e