### PR TITLE
feat: add telegram webhook keeper audit

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -58,3 +58,5 @@
 // supabase functions schedule create "0 2 1 * *" rotate-webhook-secret
 // Auto-review: every 10 minutes
 // supabase functions schedule create "*/10 * * * *" payments-auto-review
+// Telegram webhook keeper: every 15 minutes
+// supabase functions schedule create "*/15 * * * *" telegram-webhook-keeper

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,3 +56,7 @@ verify_jwt = false
 
 [functions.miniapp]
 verify_jwt = false
+
+[functions.telegram-webhook-keeper]
+verify_jwt = false
+schedule = "*/15 * * * *"


### PR DESCRIPTION
## Summary
- add `telegram-webhook-keeper` with admin-protected `/run` audit and `/version` endpoint
- ensure webhook and chat menu button are corrected if drifting and document cron schedule

## Testing
- `deno fmt supabase/functions/telegram-webhook-keeper/index.ts`
- `deno fmt deno.jsonc`
- `deno test -A supabase/functions/_tests` *(failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_689ffd94e2f48322827c3faee86d7517