### PR TITLE
feat: update mini app links

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -238,7 +238,6 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
   }
 
   const rawUrl = optionalEnv("MINI_APP_URL") || "";
-  const short = optionalEnv("MINI_APP_SHORT_NAME") || "";
 
   // Normalize MINI_APP_URL if present
   let miniUrl: string | null = null;
@@ -271,8 +270,8 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
     return miniUrl;
   }
 
-  if (short && botUsername) {
-    const deepLink = `https://t.me/${botUsername}/${short}`;
+  if (botUsername) {
+    const deepLink = `https://t.me/${botUsername}?startapp=1`;
     await sendMessage(
       chatId,
       `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -88,7 +88,6 @@ export async function handler(req: Request): Promise<Response> {
     const handlers: Record<string, CommandHandler> = {
       "/start": async (chatId) => {
         const rawUrl = optionalEnv("MINI_APP_URL") || "";
-        const short = optionalEnv("MINI_APP_SHORT_NAME") || "";
         const botUsername = optionalEnv("TELEGRAM_BOT_USERNAME") || "";
 
         let miniUrl: string | null = null;
@@ -116,8 +115,8 @@ export async function handler(req: Request): Promise<Response> {
           return;
         }
 
-        if (short && botUsername) {
-          const deepLink = `https://t.me/${botUsername}/${short}`;
+        if (botUsername) {
+          const deepLink = `https://t.me/${botUsername}?startapp=1`;
           await sendMessage(
             chatId,
             `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,

--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -159,7 +159,7 @@ Deno.test("/start shows packages/promos for returning users", async () => {
 Deno.test("/start deep-link used when MINI_APP_URL missing", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.delete("MINI_APP_URL");
-  Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
+  Deno.env.delete("MINI_APP_SHORT_NAME");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   Deno.env.set("SUPABASE_URL", "http://local");
@@ -199,7 +199,7 @@ Deno.test("/start deep-link used when MINI_APP_URL missing", async () => {
     const second = JSON.parse(calls[1].body);
     assertEquals(
       second.text,
-      "Join the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      "Join the VIP Mini App: https://t.me/mybot?startapp=1\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
     );
     assertEquals(second.reply_markup, undefined);
   } finally {

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 
+async function setConfig(key: string, val: unknown) {
+  const mod = await import("../supabase/functions/_shared/config.ts");
+  await mod.setConfig(key, val);
+}
+
 Deno.test("webhook handles /start with params", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.set(
@@ -7,13 +12,21 @@ Deno.test("webhook handles /start with params", async () => {
     "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/",
   );
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  Deno.env.set("SUPABASE_URL", "http://local");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
-    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const url = String(input);
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ url, body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
   };
   try {
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
@@ -34,22 +47,34 @@ Deno.test("webhook handles /start with params", async () => {
     );
   } finally {
     globalThis.fetch = originalFetch;
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("SUPABASE_ANON_KEY");
   }
 });
 
-Deno.test("webhook uses short name when URL absent", async () => {
+Deno.test("webhook uses startapp link when URL absent", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.delete("MINI_APP_URL");
-  Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
+  Deno.env.delete("MINI_APP_SHORT_NAME");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  Deno.env.set("SUPABASE_URL", "http://local");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
-    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const url = String(input);
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ url, body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
   };
   try {
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
@@ -65,11 +90,15 @@ Deno.test("webhook uses short name when URL absent", async () => {
     const payload = JSON.parse(calls[0].body);
     assertEquals(
       payload.text,
-      "Join the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      "Join the VIP Mini App: https://t.me/mybot?startapp=1\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
     );
     assertEquals(payload.reply_markup, undefined);
   } finally {
     globalThis.fetch = originalFetch;
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("SUPABASE_ANON_KEY");
   }
 });
 
@@ -79,13 +108,21 @@ Deno.test("webhook falls back for invalid mini app url", async () => {
   Deno.env.delete("MINI_APP_SHORT_NAME");
   Deno.env.delete("TELEGRAM_BOT_USERNAME");
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  Deno.env.set("SUPABASE_URL", "http://local");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
   const calls: Array<{ url: string; body: string }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
-    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const url = String(input);
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ url, body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
   };
   try {
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: true } });
     const mod = await import("../supabase/functions/telegram-webhook/index.ts");
     const req = new Request("https://example.com", {
       method: "POST",
@@ -100,8 +137,12 @@ Deno.test("webhook falls back for invalid mini app url", async () => {
     assertEquals(calls.length, 1);
     const payload = JSON.parse(calls[0].body);
     assertEquals(payload.text, "Bot activated. Mini app is being configured. Please try again soon.");
-    assertEquals(payload.chat_id, 1);
+    assertEquals(payload.reply_markup, undefined);
   } finally {
     globalThis.fetch = originalFetch;
+    await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("SUPABASE_ANON_KEY");
   }
 });


### PR DESCRIPTION
## Summary
- link to Telegram mini app via startapp when MINI_APP_URL is unset
- avoid sending web_app button unless MINI_APP_URL is HTTPS
- update webhook handlers and tests for new deep link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fff85fb048322b97df2a630d592a5