### PR TITLE
feat: improve miniapp diagnostics and headers

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -22,8 +22,9 @@ Deno.test("returns fallback HTML when index.html fails to load", async () => {
       body,
       "Static <code>index.html</code> not found in bundle",
     );
+    assertStringIncludes(body, "/miniapp/version");
+    assertStringIncludes(body, "<button");
   } finally {
-    (Deno as unknown as { readFile: typeof Deno.readFile }).readFile =
-      original;
+    (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = original;
   }
 });

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { ok, nf, mna } from "../_shared/http.ts";
+import { mna, nf, ok } from "../_shared/http.ts";
 
 const SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
@@ -49,8 +49,12 @@ async function indexHtml() {
       </head><body>
       <h1>Dynamic Capital VIP</h1>
       <p>Static <code>index.html</code> not found in bundle — showing fallback.</p>
+      <p>If the issue persists, use diagnostics below.</p>
+      <button onclick="location.href='/miniapp/version'">Check Version</button>
       </body></html>`;
-    const h = withSec(new Headers({ "content-type": "text/html; charset=utf-8" }));
+    const h = withSec(
+      new Headers({ "content-type": "text/html; charset=utf-8" }),
+    );
     return new Response(html, { headers: h, status: 200 });
   }
   const h = new Headers(r.headers);
@@ -73,7 +77,9 @@ export async function handler(req: Request): Promise<Response> {
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "miniapp", ts: new Date().toISOString() });
   }
-  if (req.method === "HEAD") return new Response(null, { status: 200 });
+  if (req.method === "HEAD") {
+    return new Response(null, { status: 200, headers: withSec(new Headers()) });
+  }
   if (req.method !== "GET") return mna();
 
   // Only serve these routes
@@ -94,4 +100,3 @@ export async function handler(req: Request): Promise<Response> {
 if (import.meta.main) {
   serve(handler);
 }
-

--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -19,6 +19,11 @@ Deno.test({
     assertEquals(resVersion.status, 200);
     await resVersion.arrayBuffer();
 
+    const resHead = await fetch(`${base}/miniapp/`, { method: "HEAD" });
+    assertEquals(resHead.status, 200);
+    assertEquals(resHead.headers.get("x-content-type-options"), "nosniff");
+    await resHead.arrayBuffer();
+
     const resNotFound = await fetch(`${base}/miniapp/nope`);
     assertEquals(resNotFound.status, 404);
     await resNotFound.arrayBuffer();


### PR DESCRIPTION
## Summary
- add diagnostics note and version button to miniapp fallback HTML
- include security headers in HEAD requests
- test fallback diagnostics and HEAD header handling

## Testing
- `deno test --no-npm --unsafely-ignore-certificate-errors=deno.land -A supabase/functions/miniapp/fallback.test.ts tests/miniapp-edge-host-routing.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a0020c3df883228f1c29adf0ef6dde