### PR TITLE
feat: add ops deployment and smoke scripts

### DIFF
--- a/scripts/ops/smoke.sh
+++ b/scripts/ops/smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF is required}"
+
+BASE="https://${SUPABASE_PROJECT_REF}.functions.supabase.co"
+
+check() {
+  local method=$1
+  local path=$2
+  local expected=$3
+  local data=${4-}
+  local code
+  if [[ "$method" == HEAD ]]; then
+    code=$(curl -s -o /dev/null -w '%{http_code}' -I "$BASE$path")
+  else
+    if [[ -n "$data" ]]; then
+      code=$(curl -s -o /dev/null -w '%{http_code}' -X "$method" "$BASE$path" -d "$data")
+    else
+      code=$(curl -s -o /dev/null -w '%{http_code}' -X "$method" "$BASE$path")
+    fi
+  fi
+  if [[ "$code" != "$expected" ]]; then
+    echo "[!] $method $path expected $expected got $code" >&2
+    exit 1
+  else
+    echo "[OK] $method $path -> $code"
+  fi
+}
+
+check GET /telegram-bot/version 200
+check GET /telegram-bot 405
+check POST /telegram-bot 401
+check GET /miniapp/version 200
+check HEAD /miniapp 200
+check GET /miniapp/foo 404

--- a/scripts/ops/sync-audit.sh
+++ b/scripts/ops/sync-audit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_ACCESS_TOKEN:?SUPABASE_ACCESS_TOKEN is required}"
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF is required}"
+: "${ADMIN_API_SECRET:?ADMIN_API_SECRET is required}"
+
+functions=(miniapp telegram-bot sync-audit telegram-webhook-keeper)
+for fn in "${functions[@]}"; do
+  npx supabase functions deploy "$fn" --project-ref "$SUPABASE_PROJECT_REF"
+done
+
+version=$(date -u +"%Y%m%d%H%M%S")
+
+curl -sS --fail -X POST \
+  "https://${SUPABASE_PROJECT_REF}.functions.supabase.co/sync-audit" \
+  -H "Authorization: Bearer ${ADMIN_API_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d "{\"fix\":true,\"version\":\"${version}\"}"


### PR DESCRIPTION
## Summary
- add sync-audit deployment script to push functions and trigger audit
- introduce smoke script to check telegram-bot and miniapp endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0024336348322998144198a92c886