### PR TITLE
Enable default mini app checkout

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -229,7 +229,7 @@ function hasValidMiniAppUrl(): boolean {
 
 export async function sendMiniAppLink(chatId: number): Promise<string | null> {
   if (!BOT_TOKEN) return null;
-  if (!(await getFlag("mini_app_enabled"))) {
+  if (!(await getFlag("mini_app_enabled", true))) {
     await sendMessage(
       chatId,
       "Checkout is currently unavailable. Please try again later.",


### PR DESCRIPTION
## Summary
- default to enabling mini app checkout unless the `mini_app_enabled` flag is explicitly disabled
- add tests ensuring default checkout availability and refactor feature flag tests to use shared config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a03a705d8883228c38bbf17316b3f2