### PR TITLE
feat: cache miniapp static and tighten security

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,16 +1,19 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { mna, nf, ok } from "../_shared/http.ts";
 
+const STATIC_CACHE = new Map<string, Response>();
+
 const SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-content-type-options": "nosniff",
   "permissions-policy": "geolocation=(), microphone=(), camera=()",
+  "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
   "content-security-policy":
     "default-src 'self' https://*.telegram.org https://telegram.org; " +
     "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
     "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; " +
     "connect-src 'self' https://*.functions.supabase.co https://*.supabase.co; " +
-    "frame-ancestors *;",
+    "frame-ancestors https://web.telegram.org https://*.telegram.org;",
 };
 
 function withSec(h: Headers) {
@@ -19,6 +22,8 @@ function withSec(h: Headers) {
 }
 
 async function readStatic(relPath: string, type = "application/octet-stream") {
+  const cached = STATIC_CACHE.get(relPath);
+  if (cached) return cached.clone();
   try {
     const url = new URL(`./static/${relPath}`, import.meta.url);
     const data = await Deno.readFile(url);
@@ -30,10 +35,37 @@ async function readStatic(relPath: string, type = "application/octet-stream") {
           : "public, max-age=31536000, immutable",
       }),
     );
-    return new Response(data, { headers: h });
+    const r = new Response(data, { headers: h });
+    STATIC_CACHE.set(relPath, r);
+    return r.clone();
   } catch {
     return nf("Not Found");
   }
+}
+
+async function maybeCompress(req: Request, res: Response): Promise<Response> {
+  const enc = req.headers.get("accept-encoding") ?? "";
+  let encoding: "br" | "gzip" | null = null;
+  if (enc.includes("br")) encoding = "br";
+  else if (enc.includes("gzip")) encoding = "gzip";
+  if (!encoding) return res;
+
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.startsWith("text/html") && !ct.startsWith("application/json")) {
+    return res;
+  }
+
+  const data = await res.arrayBuffer();
+  if (data.byteLength < 1024) {
+    return new Response(data, { status: res.status, headers: res.headers });
+  }
+
+  const cs = new CompressionStream(encoding);
+  const stream = new Response(data).body!.pipeThrough(cs);
+  const h = new Headers(res.headers);
+  h.set("content-encoding", encoding);
+  h.delete("content-length");
+  return new Response(stream, { status: res.status, headers: h });
 }
 
 async function indexHtml() {
@@ -75,10 +107,19 @@ function mime(p: string) {
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
-    return ok({ name: "miniapp", ts: new Date().toISOString() });
+    return await maybeCompress(
+      req,
+      ok({ name: "miniapp", ts: new Date().toISOString() }),
+    );
   }
   if (req.method === "HEAD") {
-    return new Response(null, { status: 200, headers: withSec(new Headers()) });
+    if (url.pathname === "/miniapp/" || url.pathname === "/miniapp/version") {
+      return new Response(null, {
+        status: 200,
+        headers: withSec(new Headers()),
+      });
+    }
+    return mna();
   }
   if (req.method !== "GET") return mna();
 
@@ -88,11 +129,11 @@ export async function handler(req: Request): Promise<Response> {
     url.pathname === "/miniapp" ||
     url.pathname === "/miniapp/"
   ) {
-    return await indexHtml();
+    return await maybeCompress(req, await indexHtml());
   }
   if (url.pathname.startsWith("/assets/")) {
     const rel = url.pathname.replace(/^\//, "");
-    return await readStatic(rel, mime(rel));
+    return await maybeCompress(req, await readStatic(rel, mime(rel)));
   }
   return nf("Not Found");
 }


### PR DESCRIPTION
## Summary
- memoize static file responses for miniapp
- add HSTS and restrict frame ancestors
- compress large HTML/JSON responses based on client encoding
- narrow HEAD request handling to miniapp endpoints

## Testing
- `deno fmt supabase/functions/miniapp/index.ts`
- `deno lint supabase/functions/miniapp/index.ts`
- `deno check supabase/functions/miniapp/index.ts` *(fails: invalid peer certificate)*
- `deno test supabase/functions/miniapp` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68a03e368d208322926b552b02eac504