### PR TITLE
feat: improve telegram mini app link handling

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -123,7 +123,13 @@ async function sendMessage(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_id: chatId, text, ...extra }),
+        body: JSON.stringify({
+          chat_id: chatId,
+          text,
+          disable_web_page_preview: true,
+          allow_sending_without_reply: true,
+          ...extra,
+        }),
       },
     );
     const outText = await r.text();
@@ -269,19 +275,9 @@ export async function sendMiniAppLink(chatId: number): Promise<string | null> {
     }
     return miniUrl;
   }
-
-  if (botUsername) {
-    const deepLink = `https://t.me/${botUsername}?startapp=1`;
-    await sendMessage(
-      chatId,
-      `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
-    );
-    return deepLink;
-  }
-
   await sendMessage(
     chatId,
-    "Welcome! Mini app is being configured. Please try again soon.",
+    "Mini app is not configured. Please set MINI_APP_URL.",
   );
   return null;
 }

--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -156,7 +156,7 @@ Deno.test("/start shows packages/promos for returning users", async () => {
   }
 });
 
-Deno.test("/start deep-link used when MINI_APP_URL missing", async () => {
+Deno.test("/start advises to set MINI_APP_URL when missing", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.delete("MINI_APP_URL");
   Deno.env.delete("MINI_APP_SHORT_NAME");
@@ -197,10 +197,7 @@ Deno.test("/start deep-link used when MINI_APP_URL missing", async () => {
     const first = JSON.parse(calls[0].body);
     assertEquals(first.text, "Welcome new user");
     const second = JSON.parse(calls[1].body);
-    assertEquals(
-      second.text,
-      "Join the VIP Mini App: https://t.me/mybot?startapp=1\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
-    );
+    assertEquals(second.text, "Mini app is not configured. Please set MINI_APP_URL.");
     assertEquals(second.reply_markup, undefined);
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- disable link previews and allow sending without reply in Telegram sendMessage helper
- instruct users to configure MINI_APP_URL instead of falling back to t.me link
- test coverage for missing MINI_APP_URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a03fa241a88322956fea8227a85354