### PR TITLE
Include mini app static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ apps/miniapp-react/package-lock.json
 
 # Include mini app static assets for deployment
 # (previously ignored to keep directory empty)
+!supabase/functions/miniapp/static/**
 
 # Audit reports
 .audit/


### PR DESCRIPTION
## Summary
- include Supabase mini app static assets in version control

## Testing
- `npm test` *(fails: sh: 1: deno: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04973d9b88322a9b41b0ef2f212a4