### PR TITLE
refactor miniapp handler to read static index directly

### DIFF
--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
-import { handler } from "../supabase/functions/miniapp/index.ts";
+import handler from "../supabase/functions/miniapp/index.ts";
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
 Deno.test({
@@ -13,7 +13,9 @@ Deno.test({
 
     try {
       await Deno.remove("supabase/functions/miniapp/static/assets/foo.css");
-    } catch {}
+    } catch {
+      // ignore
+    }
 
     const resRoot = await fetch(`${base}/miniapp/`);
     assertEquals(resRoot.status, 200);
@@ -70,6 +72,8 @@ Deno.test({
     controller.abort();
     try {
       await Deno.remove("supabase/functions/miniapp/static/assets/foo.css");
-    } catch {}
+    } catch {
+      // ignore
+    }
   },
 });


### PR DESCRIPTION
## Summary
- read miniapp index.html via `Deno.readFile` with fallback warning
- export handler as default and start via `Deno.serve`
- update tests for default handler import

## Testing
- `deno lint supabase/functions/miniapp/index.ts tests/miniapp-edge-host-routing.test.ts`
- `deno check supabase/functions/miniapp/index.ts`
- `deno test -A tests/miniapp-edge-host.test.ts tests/miniapp-edge-host-routing.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a04bff3e7c83228b6e78de2a79fc28