### PR TITLE
test: verify miniapp packaging and routing

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -1,3 +1,4 @@
+import handler from "./index.ts";
 import {
   assertEquals,
   assertStringIncludes,
@@ -10,11 +11,6 @@ Deno.test("returns fallback HTML when index.html fails to load", async () => {
   };
 
   try {
-    const mod = await import("./index.ts");
-    const handler = (mod as {
-      handler: (req: Request) => Promise<Response>;
-    }).handler;
-
     const res = await handler(new Request("http://example.com/"));
     assertEquals(res.status, 200);
     const body = await res.text();

--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import handler from "../supabase/functions/miniapp/index.ts";
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
@@ -19,7 +19,11 @@ Deno.test({
 
     const resRoot = await fetch(`${base}/miniapp/`);
     assertEquals(resRoot.status, 200);
-    await resRoot.arrayBuffer();
+    const bodyRoot = await resRoot.text();
+    assert(
+      !bodyRoot.includes("Static <code>index.html</code> not found"),
+      "should not serve fallback HTML",
+    );
 
     const resVersion = await fetch(`${base}/miniapp/version`);
     assertEquals(resVersion.status, 200);

--- a/tests/miniapp-packaging.test.ts
+++ b/tests/miniapp-packaging.test.ts
@@ -1,0 +1,7 @@
+import fs from "node:fs";
+import { assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("miniapp packaging bundles index.html", () => {
+  const path = "supabase/functions/miniapp/static/index.html";
+  assert(fs.existsSync(path), `${path} is missing`);
+});


### PR DESCRIPTION
## Summary
- ensure miniapp bundle includes its built index.html
- route tests verify built HTML is served instead of fallback
- simplify fallback test by importing handler directly

## Testing
- `npm test tests/miniapp-packaging.test.ts tests/miniapp-edge-host-routing.test.ts supabase/functions/miniapp/fallback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a04d5e20d48322a9eb8998b048d61a