### PR TITLE
ci: add miniapp packaging test job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,3 +17,13 @@ jobs:
         with:
           deno-version: v1.x
       - run: deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
+  miniapp-packaging:
+    runs-on: ubuntu-latest
+    env:
+      DENO_TLS_CA_STORE: system
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno test tests/miniapp-packaging.test.ts


### PR DESCRIPTION
## Summary
- add GitHub workflow job to run miniapp packaging tests with Deno

## Testing
- `deno test tests/miniapp-packaging.test.ts` *(fails: Import '...miniapp-packaging.test.ts' failed, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04d61a31c8322b7c9fff5f76788ea