### PR TITLE
ci: verify miniapp bundle before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+      - name: Verify Mini App bundle
+        run: node scripts/assert-miniapp-bundle.mjs
       - name: Deploy Mini App
         run: echo "Deploy Mini App to staging"
 
@@ -80,5 +82,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+      - name: Verify Mini App bundle
+        run: node scripts/assert-miniapp-bundle.mjs
       - name: Deploy Mini App
         run: echo "Deploy Mini App to production"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,7 +19,12 @@ Run basic checks before deploying:
 ```bash
 deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
 deno test -A
+node scripts/assert-miniapp-bundle.mjs
 ```
+
+The bundle check above fails if `supabase/functions/miniapp/static/index.html` is
+missing or unexpectedly small, and deployment should be halted until the issue
+is resolved.
 
 ## Deployment steps
 


### PR DESCRIPTION
## Summary
- check that miniapp bundle contains a sufficiently-sized index.html before deploying
- document miniapp bundle verification in deployment guide

## Testing
- `node scripts/assert-miniapp-bundle.mjs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a05902cbb08322b5e693c8abb4b801