### PR TITLE
feat: inline short name fallback for Telegram webhook

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -88,6 +88,7 @@ export async function handler(req: Request): Promise<Response> {
     const handlers: Record<string, CommandHandler> = {
       "/start": async (chatId) => {
         const rawUrl = optionalEnv("MINI_APP_URL") || "";
+        const shortName = optionalEnv("MINI_APP_SHORT_NAME") || "";
         const botUsername = optionalEnv("TELEGRAM_BOT_USERNAME") || "";
 
         let miniUrl: string | null = null;
@@ -115,12 +116,15 @@ export async function handler(req: Request): Promise<Response> {
           return;
         }
 
-        if (botUsername) {
-          const deepLink = `https://t.me/${botUsername}?startapp=1`;
-          await sendMessage(
-            chatId,
-            `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
-          );
+        if (shortName && botUsername) {
+          await sendMessage(chatId, "Join the VIP Mini App:", {
+            reply_markup: {
+              inline_keyboard: [[{
+                text: "Join",
+                url: `https://t.me/${botUsername}/${shortName}`,
+              }]],
+            },
+          });
           return;
         }
 

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -51,13 +51,15 @@ Deno.test("webhook handles /start with params", async () => {
     Deno.env.delete("SUPABASE_URL");
     Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
     Deno.env.delete("SUPABASE_ANON_KEY");
+    Deno.env.delete("MINI_APP_SHORT_NAME");
+    Deno.env.delete("TELEGRAM_BOT_USERNAME");
   }
 });
 
-Deno.test("webhook uses startapp link when URL absent", async () => {
+Deno.test("webhook uses short name link when URL absent", async () => {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
   Deno.env.delete("MINI_APP_URL");
-  Deno.env.delete("MINI_APP_SHORT_NAME");
+  Deno.env.set("MINI_APP_SHORT_NAME", "shorty");
   Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
   Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
   Deno.env.set("SUPABASE_URL", "http://local");
@@ -88,11 +90,11 @@ Deno.test("webhook uses startapp link when URL absent", async () => {
     assertEquals(res.status, 200);
     assertEquals(calls.length, 1);
     const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.text, "Join the VIP Mini App:");
     assertEquals(
-      payload.text,
-      "Join the VIP Mini App: https://t.me/mybot?startapp=1\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      payload.reply_markup.inline_keyboard[0][0].url,
+      "https://t.me/mybot/shorty",
     );
-    assertEquals(payload.reply_markup, undefined);
   } finally {
     globalThis.fetch = originalFetch;
     await setConfig("features:published", { ts: Date.now(), data: { mini_app_enabled: false } });


### PR DESCRIPTION
## Summary
- add MINI_APP_SHORT_NAME inline button fallback when MINI_APP_URL missing
- drop legacy `startapp=1` text-link path
- test short name launch path in webhook handler

## Testing
- `npm test tests/telegram-webhook.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a05eac9e208322bb0216898e3bd139