### PR TITLE
feat: add Vary header for compressed miniapp responses

### DIFF
--- a/supabase/functions/miniapp/compression.test.ts
+++ b/supabase/functions/miniapp/compression.test.ts
@@ -1,0 +1,19 @@
+import handler from "./index.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("sets Vary header when compressing", async () => {
+  const original = Deno.readFile;
+  const big = new TextEncoder().encode("a".repeat(2000));
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = () =>
+    Promise.resolve(big);
+  try {
+    const req = new Request("http://example.com/miniapp/", {
+      headers: { "accept-encoding": "gzip" },
+    });
+    const res = await handler(req);
+    assertEquals(res.headers.get("content-encoding"), "gzip");
+    assertEquals(res.headers.get("vary"), "Accept-Encoding");
+  } finally {
+    (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = original;
+  }
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -64,6 +64,16 @@ async function maybeCompress(req: Request, res: Response): Promise<Response> {
   const stream = new Response(data).body!.pipeThrough(cs);
   const h = new Headers(res.headers);
   h.set("content-encoding", encoding);
+  const vary = h.get("vary");
+  if (vary) {
+    const values = vary.split(/,\s*/);
+    if (!values.map((v) => v.toLowerCase()).includes("accept-encoding")) {
+      values.push("Accept-Encoding");
+    }
+    h.set("vary", values.join(", "));
+  } else {
+    h.set("vary", "Accept-Encoding");
+  }
   h.delete("content-length");
   return new Response(stream, { status: res.status, headers: h });
 }


### PR DESCRIPTION
## Summary
- include `Vary: Accept-Encoding` when miniapp responses are compressed
- test miniapp compression adds Vary header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a070aae72083228bfdb6272a491dc3