### PR TITLE
feat: centralize subscription activation and admin auth

### DIFF
--- a/supabase/functions/_shared/subscriptions.ts
+++ b/supabase/functions/_shared/subscriptions.ts
@@ -1,0 +1,56 @@
+import { createClient } from "./client.ts";
+
+export async function activateSubscription(
+  { telegramId, planId, paymentId }:
+    { telegramId: string | number; planId: string; paymentId: string },
+): Promise<string> {
+  const supa = createClient();
+
+  const { data: user } = await supa
+    .from("bot_users")
+    .select("id,subscription_expires_at")
+    .eq("telegram_id", telegramId)
+    .maybeSingle();
+  if (!user) throw new Error("User not found");
+
+  const { data: plan } = await supa
+    .from("subscription_plans")
+    .select("duration_months,is_lifetime")
+    .eq("id", planId)
+    .maybeSingle();
+
+  const months = plan?.is_lifetime
+    ? 1200
+    : (plan?.duration_months || 1);
+  const now = new Date();
+  const base = user.subscription_expires_at &&
+      new Date(user.subscription_expires_at) > now
+    ? new Date(user.subscription_expires_at)
+    : now;
+  const next = new Date(base);
+  next.setMonth(next.getMonth() + months);
+  const expiresAt = next.toISOString();
+
+  await supa
+    .from("payments")
+    .update({ status: "completed" })
+    .eq("id", paymentId)
+    .single();
+
+  await supa.from("user_subscriptions").upsert({
+    telegram_user_id: telegramId,
+    plan_id: planId,
+    payment_status: "completed",
+    is_active: true,
+    subscription_start_date: now.toISOString(),
+    subscription_end_date: expiresAt,
+  }, { onConflict: "telegram_user_id" });
+
+  await supa
+    .from("bot_users")
+    .update({ is_vip: true, subscription_expires_at: expiresAt })
+    .eq("id", user.id)
+    .single();
+
+  return expiresAt;
+}

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -1,83 +1,119 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
-import { ok, bad, nf, mna, unauth } from "../_shared/http.ts";
+import { ok, bad, nf, mna, unauth, oops } from "../_shared/http.ts";
 import { requireEnv } from "../_shared/env.ts";
+import { activateSubscription } from "../_shared/subscriptions.ts";
 
-type Body = { initData: string; payment_id: string; decision: "approve"|"reject"; months?: number; message?: string };
+type Body = {
+  initData?: string;
+  payment_id: string;
+  decision: "approve" | "reject";
+  message?: string;
+};
 
 async function tgSend(token: string, chatId: string, text: string) {
   await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
-    method: "POST", headers: { "content-type":"application/json" },
-    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" })
-  }).catch(()=>{});
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+  }).catch(() => {});
 }
 
 export async function handler(req: Request): Promise<Response> {
-  const url = new URL(req.url);
-  if (req.method === "GET" && url.pathname.endsWith("/version")) {
-    return ok({ name: "admin-act-on-payment", ts: new Date().toISOString() });
-  }
-  if (req.method === "HEAD") return new Response(null, { status: 200 });
-  if (req.method !== "POST") return mna();
-  let body: Body; try { body = await req.json(); } catch { return bad("Bad JSON"); }
+  try {
+    const url = new URL(req.url);
+    if (req.method === "GET" && url.pathname.endsWith("/version")) {
+      return ok({ name: "admin-act-on-payment", ts: new Date().toISOString() });
+    }
+    if (req.method === "HEAD") return ok();
+    if (req.method !== "POST") return mna();
 
-  const u = await verifyInitDataAndGetUser(body.initData || "");
-  if (!u || !isAdmin(u.id)) return unauth();
+    let body: Body;
+    try {
+      body = await req.json();
+    } catch {
+      return bad("Bad JSON");
+    }
 
-  const { TELEGRAM_BOT_TOKEN: bot } =
-    requireEnv(["TELEGRAM_BOT_TOKEN"] as const);
-  const supa = createClient();
+    const hdr = req.headers.get("X-Admin-Secret") || "";
+    const expect = Deno.env.get("ADMIN_API_SECRET") || "";
+    let adminId = "unknown";
 
-  // Load payment + user + plan
-  const { data: p } = await supa.from("payments").select("id,status,user_id,plan_id,amount,currency,created_at").eq("id", body.payment_id).maybeSingle();
-  if (!p) return nf("Payment not found");
-  const { data: user } = await supa.from("bot_users").select("id,telegram_id,subscription_expires_at,is_vip").eq("id", p.user_id).maybeSingle();
-  if (!user) return nf("User not found");
+    if (hdr) {
+      if (hdr !== expect) return unauth();
+    } else {
+      const u = await verifyInitDataAndGetUser(body.initData || "");
+      if (!u || !isAdmin(u.id)) return unauth();
+      adminId = String(u.id);
+    }
 
-  if (body.decision === "reject") {
-    await supa.from("payments").update({ status: "failed" }).eq("id", p.id).single();
-    if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `❌ <b>Payment Failed</b>\\n${body.message || "Please contact support."}`);
-    await supa.from("admin_logs").insert({
-      admin_telegram_id: String(u.id),
-      action_type: "payment_failed",
-      action_description: `Payment ${p.id} marked as failed`,
-      affected_table: "payments",
-      affected_record_id: p.id,
-      new_values: { status: "failed" }
+    const { TELEGRAM_BOT_TOKEN: bot } =
+      requireEnv(["TELEGRAM_BOT_TOKEN"] as const);
+    const supa = createClient();
+
+    const { data: p } = await supa
+      .from("payments")
+      .select("id,status,user_id,plan_id,amount,currency,created_at")
+      .eq("id", body.payment_id)
+      .maybeSingle();
+    if (!p) return nf("Payment not found");
+    const { data: user } = await supa
+      .from("bot_users")
+      .select("id,telegram_id,subscription_expires_at,is_vip")
+      .eq("id", p.user_id)
+      .maybeSingle();
+    if (!user) return nf("User not found");
+
+    if (body.decision === "reject") {
+      await supa.from("payments").update({ status: "failed" }).eq("id", p.id)
+        .single();
+      if (user.telegram_id) {
+        await tgSend(
+          bot,
+          String(user.telegram_id),
+          `❌ <b>Payment Failed</b>\\n${body.message || "Please contact support."}`,
+        );
+      }
+      await supa.from("admin_logs").insert({
+        admin_telegram_id: adminId,
+        action_type: "payment_failed",
+        action_description: `Payment ${p.id} marked as failed`,
+        affected_table: "payments",
+        affected_record_id: p.id,
+        new_values: { status: "failed" },
+      });
+      return ok({ status: "failed" });
+    }
+
+    const expiresAt = await activateSubscription({
+      telegramId: user.telegram_id,
+      planId: p.plan_id,
+      paymentId: p.id,
     });
-    return ok({ status: "failed" });
+
+    if (user.telegram_id) {
+      await tgSend(
+        bot,
+        String(user.telegram_id),
+        `✅ <b>VIP Activated</b>\\nValid until <b>${
+          new Date(expiresAt).toLocaleDateString()
+        }</b>.`,
+      );
+    }
+    await supa.from("admin_logs").insert({
+      admin_telegram_id: adminId,
+      action_type: "payment_completed",
+      action_description: `Payment ${p.id} completed; VIP until ${expiresAt}`,
+      affected_table: "bot_users",
+      affected_record_id: user.id,
+      new_values: { is_vip: true, subscription_expires_at: expiresAt },
+    });
+
+    return ok({ status: "completed", subscription_expires_at: expiresAt });
+  } catch (e) {
+    return oops("Internal Error", String(e));
   }
-
-  // approve
-  let months = Number.isFinite(body.months) ? Number(body.months) : null;
-  if (!months) {
-    const { data: plan } = await supa.from("subscription_plans").select("duration_months,is_lifetime").eq("id", p.plan_id).maybeSingle();
-    months = plan?.is_lifetime ? 1200 : (plan?.duration_months || 1);
-  }
-
-  const now = new Date();
-  const base = user.subscription_expires_at && new Date(user.subscription_expires_at) > now ? new Date(user.subscription_expires_at) : now;
-  const next = new Date(base); next.setMonth(next.getMonth() + (months || 1));
-  const expiresAt = next.toISOString();
-
-  await supa.from("payments").update({ status: "completed" }).eq("id", p.id).single();
-  await supa.from("user_subscriptions").upsert({
-    telegram_user_id: user.telegram_id, plan_id: p.plan_id, payment_status: "completed",
-    is_active: true, subscription_start_date: now.toISOString(), subscription_end_date: expiresAt
-  }, { onConflict: "telegram_user_id" });
-  await supa.from("bot_users").update({ is_vip: true, subscription_expires_at: expiresAt }).eq("id", user.id).single();
-
-  if (user.telegram_id) await tgSend(bot, String(user.telegram_id), `✅ <b>VIP Activated</b>\nValid until <b>${new Date(expiresAt).toLocaleDateString()}</b>.`);
-  await supa.from("admin_logs").insert({
-    admin_telegram_id: String(u.id),
-    action_type: "payment_completed",
-    action_description: `Payment ${p.id} completed; VIP until ${expiresAt}`,
-    affected_table: "bot_users", affected_record_id: user.id,
-    new_values: { is_vip: true, subscription_expires_at: expiresAt }
-  });
-
-  return ok({ status: "completed", subscription_expires_at: expiresAt });
 }
 
 if (import.meta.main) serve(handler);


### PR DESCRIPTION
## Summary
- add shared `activateSubscription` helper
- allow `admin-act-on-payment` to use header secret or Telegram initData
- reuse subscription helper and HTTP response helpers

## Testing
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check`


------
https://chatgpt.com/codex/tasks/task_e_68a07463504083229989c08bf18f46ee