### PR TITLE
Enforce unique telegram_user_id constraint for user subscriptions

### DIFF
--- a/supabase/migrations/20250817000100_user_subscriptions_unique_telegram.sql
+++ b/supabase/migrations/20250817000100_user_subscriptions_unique_telegram.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.user_subscriptions
+  ADD CONSTRAINT user_subscriptions_telegram_user_id_key UNIQUE (telegram_user_id);


### PR DESCRIPTION
## Summary
- ensure `telegram_user_id` is unique in `user_subscriptions` by completing the ALTER TABLE statement with proper constraint naming

## Testing
- `su postgres -c "psql -f supabase/migrations/20250817000100_user_subscriptions_unique_telegram.sql"`
- `su postgres -c "psql -c \"INSERT INTO public.user_subscriptions (telegram_user_id) VALUES ('1');\""`
- `su postgres -c "psql -c \"INSERT INTO public.user_subscriptions (telegram_user_id) VALUES ('1');\""` (fails: duplicate key)
- `PATH=$HOME/.deno/bin:$PATH npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a09effc4d88322b30c153d5161db67