### PR TITLE
fix: enable miniapp-health tests

### DIFF
--- a/functions/_tests/miniapp-health.test.ts
+++ b/functions/_tests/miniapp-health.test.ts
@@ -11,7 +11,9 @@ Deno.env.set("SUPABASE_URL", "https://example.com");
 Deno.env.set("SUPABASE_ANON_KEY", "anon");
 Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service");
 
-let mod: Record<string, unknown> | null = null;
+let mod:
+  | typeof import("../../supabase/functions/miniapp-health/index.ts")
+  | null = null;
 try {
   mod = await import("../../supabase/functions/miniapp-health/index.ts");
 } catch {

--- a/supabase/functions/_tests/helpers.ts
+++ b/supabase/functions/_tests/helpers.ts
@@ -17,16 +17,30 @@ export async function makeTelegramInitData(
   // builds a valid WebApp initData for tests
   const enc = new TextEncoder();
   const secretKey = await crypto.subtle.digest("SHA-256", enc.encode(botToken));
-  const key = await crypto.subtle.importKey("raw", secretKey, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    secretKey,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
   const params = new URLSearchParams({
     user: encodeURIComponent(JSON.stringify(user)),
-    auth_date: String(Math.floor(Date.now()/1000)),
+    auth_date: String(Math.floor(Date.now() / 1000)),
     query_id: "TEST",
-    ...extra
+    ...extra,
   });
-  const dataCheckString = Array.from(params.entries()).map(([k,v])=>`${k}=${v}`).sort().join("\n");
-  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(dataCheckString));
-  const hash = [...new Uint8Array(sig)].map(b=>b.toString(16).padStart(2,"0")).join("");
+  const dataCheckString = Array.from(params.entries()).map(([k, v]) =>
+    `${k}=${v}`
+  ).sort().join("\n");
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    enc.encode(dataCheckString),
+  );
+  const hash = [...new Uint8Array(sig)].map((b) =>
+    b.toString(16).padStart(2, "0")
+  ).join("");
   params.set("hash", hash);
   return params.toString();
 }
@@ -35,15 +49,41 @@ export const FakeSupa = () => ({
   from: (_table: string) => ({
     _table,
     _sel: "",
-    select(sel: string) { this._sel = sel; return this; },
-    eq() { return this; },
-    limit() { return this; },
-    order() { return this; },
-    maybeSingle() { return { data: null, error: null }; },
-    range() { return { data: [], error: null }; },
-    insert() { return { data: null, error: null }; },
-    update() { return { data: null, error: null }; },
-    upsert() { return { data: null, error: null }; }
+    select(sel: string) {
+      this._sel = sel;
+      return this;
+    },
+    eq() {
+      return this;
+    },
+    limit() {
+      return this;
+    },
+    order() {
+      return this;
+    },
+    maybeSingle() {
+      return Promise.resolve({ data: null, error: null });
+    },
+    range() {
+      return Promise.resolve({ data: [], error: null });
+    },
+    insert() {
+      return Promise.resolve({ data: null, error: null });
+    },
+    update() {
+      return Promise.resolve({ data: null, error: null });
+    },
+    upsert() {
+      return Promise.resolve({ data: null, error: null });
+    },
   }),
-  storage: { from: () => ({ createSignedUrl: async () => ({ data: { signedUrl: "https://example/signed" }, error: null }) }) }
+  storage: {
+    from: () => ({
+      createSignedUrl: async () => ({
+        data: { signedUrl: "https://example/signed" },
+        error: null,
+      }),
+    }),
+  },
 });

--- a/supabase/functions/_tests/keeper_secret_test.ts
+++ b/supabase/functions/_tests/keeper_secret_test.ts
@@ -4,10 +4,23 @@ import { ensureWebhookSecret } from "../_shared/telegram_secret.ts";
 Deno.test("keeper: uses DB secret if present", async () => {
   const supa = {
     from: () => ({
-      select(){return this}, eq(){return this}, limit(){return this}, maybeSingle(){return { data: { setting_value: "db" }, error: null }},
-      upsert(){return { error: null }}
-    })
-  };
+      select() {
+        return this;
+      },
+      eq() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      maybeSingle() {
+        return { data: { setting_value: "db" }, error: null };
+      },
+      upsert() {
+        return { error: null };
+      },
+    }),
+  } as any;
   const secret = await ensureWebhookSecret(supa, "env");
   assert(secret === "db");
 });
@@ -15,10 +28,23 @@ Deno.test("keeper: uses DB secret if present", async () => {
 Deno.test("keeper: falls back to env secret", async () => {
   const supa = {
     from: () => ({
-      select(){return this}, eq(){return this}, limit(){return this}, maybeSingle(){return { data: null, error: null }},
-      upsert(){return { error: null }}
-    })
-  };
+      select() {
+        return this;
+      },
+      eq() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      maybeSingle() {
+        return { data: null, error: null };
+      },
+      upsert() {
+        return { error: null };
+      },
+    }),
+  } as any;
   const secret = await ensureWebhookSecret(supa, "env");
   assert(secret === "env");
 });
@@ -26,10 +52,23 @@ Deno.test("keeper: falls back to env secret", async () => {
 Deno.test("keeper: generates if none", async () => {
   const supa = {
     from: () => ({
-      select(){return this}, eq(){return this}, limit(){return this}, maybeSingle(){return { data: null, error: null }},
-      upsert(){return { error: null }}
-    })
-  };
+      select() {
+        return this;
+      },
+      eq() {
+        return this;
+      },
+      limit() {
+        return this;
+      },
+      maybeSingle() {
+        return { data: null, error: null };
+      },
+      upsert() {
+        return { error: null };
+      },
+    }),
+  } as any;
   const secret = await ensureWebhookSecret(supa, null);
   assert(typeof secret === "string" && secret.length >= 16);
 });

--- a/supabase/functions/_tests/miniapp_health_test.ts
+++ b/supabase/functions/_tests/miniapp_health_test.ts
@@ -6,7 +6,7 @@ Deno.test("miniapp-health: null when user not found", async () => {
   Deno.env.set("SUPABASE_ANON_KEY", "anon");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service");
   const { getVipForTelegram } = await import("../miniapp-health/index.ts");
-  const supa = FakeSupa();
+  const supa = FakeSupa() as any;
   const vip = await getVipForTelegram(supa, "2255");
   assertEquals(vip, null);
 });

--- a/supabase/functions/miniapp-health/index.ts
+++ b/supabase/functions/miniapp-health/index.ts
@@ -5,7 +5,11 @@ interface SupabaseLike {
   from: (table: string) => {
     select: (columns: string) => {
       eq: (col: string, value: string) => {
-        limit: (n: number) => Promise<{ data?: Array<Record<string, unknown>>; error?: { message: string } }>;
+        limit: (
+          n: number,
+        ) => Promise<
+          { data?: Array<Record<string, unknown>>; error?: { message: string } }
+        >;
       };
     };
   };
@@ -72,3 +76,5 @@ async function handler(req: Request): Promise<Response> {
 if (import.meta.main) {
   serve(handler);
 }
+
+export default handler;


### PR DESCRIPTION
## Summary
- export default handler for miniapp-health edge function
- fix test stubs and typing for miniapp-health and keeper secret utilities
- ensure fake supabase client returns promises for query methods

## Testing
- `deno test -A --unsafely-ignore-certificate-errors`


------
https://chatgpt.com/codex/tasks/task_e_68a0a23cc2708322b8a91673d43e3432