### PR TITLE
chore: type supabase client

### DIFF
--- a/supabase/functions/_shared/client.ts
+++ b/supabase/functions/_shared/client.ts
@@ -1,4 +1,8 @@
-import { createClient as createSupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  createClient as createSupabaseClient,
+  type SupabaseClient,
+} from "https://esm.sh/@supabase/supabase-js@2";
+import type { Database } from "../../../src/integrations/supabase/types.ts";
 import { getEnv } from "./env.ts";
 
 const url = getEnv("SUPABASE_URL");
@@ -7,7 +11,9 @@ const serviceKey = getEnv("SUPABASE_SERVICE_ROLE_KEY");
 
 const options = { auth: { persistSession: false } };
 
-export function createClient(key: "anon" | "service" = "service") {
+export function createClient(
+  key: "anon" | "service" = "service",
+): SupabaseClient<Database> {
   const k = key === "service" ? serviceKey : anonKey;
-  return createSupabaseClient(url, k, options);
+  return createSupabaseClient<Database>(url, k, options);
 }


### PR DESCRIPTION
## Summary
- use generated Database types when creating Supabase client for Edge functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a9d2d9608322a99e791c1ca422d1