### PR TITLE
fix: remove unsupported schedule key from function config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -58,5 +58,5 @@ verify_jwt = false
 verify_jwt = false
 
 [functions.telegram-webhook-keeper]
+enabled = true
 verify_jwt = false
-schedule = "*/15 * * * *"


### PR DESCRIPTION
## Summary
- remove unsupported schedule key from telegram-webhook-keeper function config
- explicitly enable function so config parses correctly

## Testing
- `deno task test`
- `npx --yes supabase functions deploy miniapp --project-ref qeejuomcapbdlhnjqjcc`


------
https://chatgpt.com/codex/tasks/task_e_68a1307b99bc83228e22d8562ae90cda