### PR TITLE
feat: add telegram init auth function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -54,6 +54,9 @@ verify_jwt = false
 [functions.tg-verify-init]
 verify_jwt = false
 
+[functions.auth-telegram-init]
+verify_jwt = false
+
 [functions.miniapp]
 verify_jwt = false
 

--- a/supabase/functions/_tests/keeper_secret_test.ts
+++ b/supabase/functions/_tests/keeper_secret_test.ts
@@ -1,74 +1,38 @@
 import { assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { ensureWebhookSecret } from "../_shared/telegram_secret.ts";
 
+type SupabaseLike = Parameters<typeof ensureWebhookSecret>[0];
+
+function mockSupa(setting: { setting_value: string } | null): SupabaseLike {
+  return {
+    from: () => {
+      const query = {
+        eq: () => query,
+        limit: () => query,
+        maybeSingle: async () => ({ data: setting }),
+      };
+      return {
+        select: () => query,
+        upsert: async () => ({ error: undefined }),
+      };
+    },
+  };
+}
+
 Deno.test("keeper: uses DB secret if present", async () => {
-  const supa = {
-    from: () => ({
-      select() {
-        return this;
-      },
-      eq() {
-        return this;
-      },
-      limit() {
-        return this;
-      },
-      maybeSingle() {
-        return { data: { setting_value: "db" }, error: null };
-      },
-      upsert() {
-        return { error: null };
-      },
-    }),
-  } as any;
+  const supa = mockSupa({ setting_value: "db" });
   const secret = await ensureWebhookSecret(supa, "env");
   assert(secret === "db");
 });
 
 Deno.test("keeper: falls back to env secret", async () => {
-  const supa = {
-    from: () => ({
-      select() {
-        return this;
-      },
-      eq() {
-        return this;
-      },
-      limit() {
-        return this;
-      },
-      maybeSingle() {
-        return { data: null, error: null };
-      },
-      upsert() {
-        return { error: null };
-      },
-    }),
-  } as any;
+  const supa = mockSupa(null);
   const secret = await ensureWebhookSecret(supa, "env");
   assert(secret === "env");
 });
 
 Deno.test("keeper: generates if none", async () => {
-  const supa = {
-    from: () => ({
-      select() {
-        return this;
-      },
-      eq() {
-        return this;
-      },
-      limit() {
-        return this;
-      },
-      maybeSingle() {
-        return { data: null, error: null };
-      },
-      upsert() {
-        return { error: null };
-      },
-    }),
-  } as any;
+  const supa = mockSupa(null);
   const secret = await ensureWebhookSecret(supa, null);
   assert(typeof secret === "string" && secret.length >= 16);
 });

--- a/supabase/functions/_tests/miniapp_health_test.ts
+++ b/supabase/functions/_tests/miniapp_health_test.ts
@@ -6,7 +6,8 @@ Deno.test("miniapp-health: null when user not found", async () => {
   Deno.env.set("SUPABASE_ANON_KEY", "anon");
   Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service");
   const { getVipForTelegram } = await import("../miniapp-health/index.ts");
-  const supa = FakeSupa() as any;
+  type SupabaseLike = Parameters<typeof getVipForTelegram>[0];
+  const supa = FakeSupa() as unknown as SupabaseLike;
   const vip = await getVipForTelegram(supa, "2255");
   assertEquals(vip, null);
 });

--- a/supabase/functions/auth/telegram-init/index.ts
+++ b/supabase/functions/auth/telegram-init/index.ts
@@ -1,0 +1,103 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { optionalEnv } from "../../_shared/env.ts";
+import { createClient } from "../../_shared/client.ts";
+import { verifyFromRaw } from "../../verify-initdata/index.ts";
+
+const mini = optionalEnv("MINI_APP_URL");
+const corsHeaders = {
+  "Access-Control-Allow-Origin": mini ? new URL(mini).origin : "",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function withCors(res: Response) {
+  Object.entries(corsHeaders).forEach(([k, v]) => res.headers.set(k, v));
+  return res;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return withCors(new Response(null, { status: 204 }));
+  }
+
+  try {
+    const { initData, ttl } = await req.json().catch(() => ({ initData: "" }));
+    if (!initData) {
+      return withCors(
+        new Response(JSON.stringify({ error: "initData required" }), {
+          status: 400,
+        }),
+      );
+    }
+
+    const valid = await verifyFromRaw(initData);
+    if (!valid) {
+      return withCors(
+        new Response(JSON.stringify({ error: "invalid init data" }), {
+          status: 401,
+        }),
+      );
+    }
+
+    const params = new URLSearchParams(initData);
+    let user: unknown = {};
+    try {
+      user = JSON.parse(params.get("user") || "{}");
+    } catch {
+      user = {};
+    }
+    const telegramId = Number((user as { id?: number }).id || 0);
+    if (!telegramId) {
+      return withCors(
+        new Response(JSON.stringify({ error: "user.id required" }), {
+          status: 400,
+        }),
+      );
+    }
+
+    const client = createClient();
+    const { data: profile, error } = await client
+      .from("profiles")
+      .upsert({ telegram_id: telegramId }, { onConflict: "telegram_id" })
+      .select()
+      .single();
+    if (error || !profile) {
+      console.error("profile upsert error", error);
+      return withCors(
+        new Response(JSON.stringify({ error: "profile upsert failed" }), {
+          status: 500,
+        }),
+      );
+    }
+
+    const payload: Record<string, unknown> = { sub: profile.id };
+    const opts: Record<string, unknown> = {};
+    const ttlNum = Number(ttl);
+    if (!isNaN(ttlNum) && ttlNum > 0) opts.expiresIn = ttlNum;
+    const auth = client.auth as unknown as {
+      signJWT: (
+        p: Record<string, unknown>,
+        o: Record<string, unknown>,
+      ) => Promise<{ access_token?: string; token?: string; jwt?: string }>
+    };
+    const signed = await auth.signJWT(payload, opts);
+    const access_token =
+      signed.access_token || signed.token || signed.jwt || "";
+
+    return withCors(
+      new Response(JSON.stringify({ access_token, profile }), {
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        },
+      }),
+    );
+  } catch (err) {
+    console.error("telegram-init error", err);
+    return withCors(
+      new Response(JSON.stringify({ error: String(err) }), {
+        status: 500,
+      }),
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `auth/telegram-init` edge function for verifying Telegram WebApp init data, upserting profiles, and issuing Supabase JWT
- prevent caching of auth responses
- configure function in `supabase/config.toml`
- replace `any` in test mocks with typed helpers to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a155983208832281fd834a8af8c7c3