### PR TITLE
Handle unknown errors in AI FAQ assistant

### DIFF
--- a/supabase/functions/ai-faq-assistant/index.ts
+++ b/supabase/functions/ai-faq-assistant/index.ts
@@ -95,10 +95,14 @@ Always end responses with: "💡 Need more help? Contact @DynamicCapital_Support
     });
   } catch (error) {
     console.error("Error in ai-faq-assistant function:", error);
+    let details = "Unknown error";
+    if (error instanceof Error) {
+      details = error.message;
+    }
     return new Response(
       JSON.stringify({
         error: "Failed to get AI response",
-        details: error.message,
+        details,
       }),
       {
         status: 500,


### PR DESCRIPTION
## Summary
- guard against non-Error values in AI FAQ assistant
- provide safer error response details

## Testing
- `deno --version`
- `deno check --no-config --unsafely-ignore-certificate-errors=deno.land supabase/functions/ai-faq-assistant/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a1745193848322af0933ae26a92ab0