### PR TITLE
feat: add cached settings and content helpers

### DIFF
--- a/supabase/functions/_shared/telegram_secret.ts
+++ b/supabase/functions/_shared/telegram_secret.ts
@@ -1,5 +1,6 @@
-import { maybe, need, optionalEnv } from "./env.ts";
+import { maybe, optionalEnv } from "./env.ts";
 import { unauth } from "./http.ts";
+import { getSetting } from "./config.ts";
 
 interface Query {
   eq: (key: string, value: string | boolean) => Query;
@@ -30,19 +31,7 @@ export async function readDbWebhookSecret(
         .maybeSingle();
       return (data?.setting_value as string) || null;
     }
-    const url = need("SUPABASE_URL");
-    const key = need("SUPABASE_SERVICE_ROLE_KEY");
-    const resp = await fetch(
-      `${url}/rest/v1/bot_settings?select=setting_value&setting_key=eq.TELEGRAM_WEBHOOK_SECRET&is_active=eq.true&limit=1`,
-      {
-        headers: {
-          apikey: key,
-          Authorization: `Bearer ${key}`,
-        },
-      },
-    );
-    const data = await resp.json().catch(() => []);
-    return (data?.[0]?.setting_value as string) || null;
+    return await getSetting<string>("TELEGRAM_WEBHOOK_SECRET");
   } catch {
     return null;
   }

--- a/supabase/functions/intent/index.ts
+++ b/supabase/functions/intent/index.ts
@@ -1,6 +1,7 @@
 import { verifyInitDataAndGetUser } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, bad, unauth, mna } from "../_shared/http.ts";
+import { getContent } from "../_shared/config.ts";
 Deno.serve(async (req) => {
   if (req.method !== "POST") return mna();
 
@@ -53,17 +54,10 @@ Deno.serve(async (req) => {
   }
 
   if (body.type === "crypto") {
-    let deposit_address = "DEMO-ADDRESS";
+    const deposit_address = await getContent<string>("crypto_usdt_trc20")
+      || "DEMO-ADDRESS";
     let userId: string | undefined;
     if (supa) {
-      const { data: addr } = await supa
-        .from("bot_content")
-        .select("content_value")
-        .eq("content_key", "crypto_usdt_trc20")
-        .eq("is_active", true)
-        .maybeSingle();
-      deposit_address = addr?.content_value || deposit_address;
-
       const { data: bu } = await supa
         .from("bot_users")
         .select("id")

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, mna, oops } from "../_shared/http.ts";
+import { envOrSetting } from "../_shared/config.ts";
 
 const need = (k: string) =>
   Deno.env.get(k) || (() => {
@@ -46,15 +47,9 @@ serve(async (req) => {
 
     const supa = createClient();
 
-    // Pull tolerance & window from bot_settings (fallbacks)
-    const { data: tolRow } = await supa.from("bot_settings").select(
-      "content_value",
-    ).eq("content_key", "AMOUNT_TOLERANCE").maybeSingle();
-    const tol = num(tolRow?.content_value) ?? 0.05; // 5%
-    const { data: winRow } = await supa.from("bot_settings").select(
-      "content_value",
-    ).eq("content_key", "WINDOW_SECONDS").maybeSingle();
-    const win = Number(winRow?.content_value ?? 7200);
+    // Pull tolerance & window from env or bot_settings
+    const tol = num(await envOrSetting("AMOUNT_TOLERANCE")) ?? 0.05; // 5%
+    const win = num(await envOrSetting("WINDOW_SECONDS")) ?? 7200;
 
     // Find recent pending with receipts
     const sinceIso = new Date(Date.now() - 24 * 3600 * 1000).toISOString();

--- a/supabase/functions/theme-get/index.ts
+++ b/supabase/functions/theme-get/index.ts
@@ -1,6 +1,6 @@
 // >>> DC BLOCK: theme-get-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { optionalEnv, requireEnv } from "../_shared/env.ts";
+import { getSetting } from "../_shared/config.ts";
 
 function parseToken(bearer: string | undefined) {
   if (!bearer?.startsWith("Bearer ")) return 0;
@@ -19,35 +19,9 @@ serve(async (req) => {
       status: 401,
     });
   }
-  // Try bot_settings(setting_key=`theme:${uid}`)
-  try {
-    const { SUPABASE_URL, SUPABASE_ANON_KEY } = requireEnv(
-      [
-        "SUPABASE_URL",
-        "SUPABASE_ANON_KEY",
-      ] as const,
-    );
-    const key = optionalEnv("SUPABASE_SERVICE_ROLE_KEY") || SUPABASE_ANON_KEY;
-    const res = await fetch(
-      `${SUPABASE_URL}/rest/v1/bot_settings?select=setting_value&setting_key=eq.theme:${uid}`,
-      {
-        headers: { apikey: key, Authorization: `Bearer ${key}` },
-      },
-    );
-    if (res.ok) {
-      const rows = await res.json();
-      const mode = (rows?.[0]?.setting_value || "auto") as
-        | "auto"
-        | "light"
-        | "dark";
-      return new Response(JSON.stringify({ mode }), {
-        headers: { "content-type": "application/json" },
-      });
-    }
-  } catch (_err) {
-    // ignore errors and fall back to default mode
-  }
-  return new Response(JSON.stringify({ mode: "auto" }), {
+  const mode = await getSetting<"auto" | "light" | "dark">(`theme:${uid}`)
+    || "auto";
+  return new Response(JSON.stringify({ mode }), {
     headers: { "content-type": "application/json" },
   });
 });


### PR DESCRIPTION
## Summary
- add internal service supabase client with 60s in-memory cache
- implement cached getSetting, requireSetting, envOrSetting and getContent helpers
- refactor functions to use shared helpers for settings and content

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a2b7f9b4832289bd429abc97bfd4