### PR TITLE
feat: add version endpoints and http helpers

### DIFF
--- a/supabase/functions/_shared/version.ts
+++ b/supabase/functions/_shared/version.ts
@@ -1,0 +1,13 @@
+import { ok, mna } from "./http.ts";
+
+export function version(req: Request, name: string): Response | null {
+  const url = new URL(req.url);
+  if (!url.pathname.endsWith("/version")) return null;
+  if (req.method === "GET") {
+    return ok({ name, ts: new Date().toISOString() });
+  }
+  if (req.method === "HEAD") {
+    return ok();
+  }
+  return mna();
+}

--- a/supabase/functions/funnel-track/index.ts
+++ b/supabase/functions/funnel-track/index.ts
@@ -1,11 +1,16 @@
-// >>> DC BLOCK: funnel-track-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { requireEnv } from "../_shared/env.ts";
+import { bad, json, ok, mna } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
+  const v = version(req, "funnel-track");
+  if (v) return v;
+  if (req.method !== "POST") return mna();
+
   const { telegram_id, step, data } = await req.json().catch(() => ({}));
   if (!telegram_id || typeof step !== "number") {
-    return new Response(JSON.stringify({ ok: false, error: "bad_request" }), { status: 400 });
+    return bad("bad_request");
   }
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
     ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
@@ -27,6 +32,7 @@ serve(async (req) => {
       },
     ]),
   });
-  return new Response(JSON.stringify({ ok: true }), { headers: { "content-type": "application/json" } });
-});
-// <<< DC BLOCK: funnel-track-core (end)
+  return ok();
+}
+
+if (import.meta.main) serve(handler);

--- a/supabase/functions/keep-alive/index.ts
+++ b/supabase/functions/keep-alive/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { getEnv } from "../_shared/env.ts";
 import { createLogger } from "../_shared/logger.ts";
+import { json, mna } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -8,7 +10,6 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-// Keep-alive function to prevent cold starts
 let keepAliveTimer: number | null = null;
 
 const baseLogger = createLogger({ function: "keep-alive" });
@@ -28,7 +29,7 @@ function startKeepAlive() {
 
   keepAliveTimer = setInterval(() => {
     baseLogger.info("Keep-alive ping:", new Date().toISOString());
-  }, 4 * 60 * 1000); // Every 4 minutes
+  }, 4 * 60 * 1000);
 }
 
 function stopKeepAlive() {
@@ -38,49 +39,45 @@ function stopKeepAlive() {
   }
 }
 
-serve((req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
+    return json({}, 200, corsHeaders);
   }
+  const v = version(req, "keep-alive");
+  if (v) return v;
+  if (req.method !== "POST") return mna();
 
   const logger = getLogger(req);
 
   try {
-    // Start keep-alive on first request
     startKeepAlive();
-
     getEnv("TELEGRAM_BOT_TOKEN");
-
     logger.info("Keep-alive service started for telegram bot");
-
-    return new Response(
-      JSON.stringify({
+    return json(
+      {
         success: true,
         message: "Keep-alive service active",
         timestamp: new Date().toISOString(),
         status: "Bot function will stay warm to reduce response lag",
-      }),
-      {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 200,
       },
+      200,
+      corsHeaders,
     );
   } catch (error) {
     logger.error("Error in keep-alive service:", error);
-    return new Response(
-      JSON.stringify({
-        error: error.message,
-        success: false,
-      }),
+    return json(
       {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 500,
+        error: (error as Error).message,
+        success: false,
       },
+      500,
+      corsHeaders,
     );
   }
-});
+}
 
-// Cleanup on shutdown
+if (import.meta.main) serve(handler);
+
 addEventListener("beforeunload", () => {
   stopKeepAlive();
   baseLogger.info("Keep-alive service stopped");

--- a/supabase/functions/plans/index.ts
+++ b/supabase/functions/plans/index.ts
@@ -1,9 +1,13 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
+import { mna, oops, ok } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
+  const v = version(req, "plans");
+  if (v) return v;
   if (req.method !== "GET") {
-    return new Response("Method Not Allowed", { status: 405 });
+    return mna();
   }
 
   const supa = createClient("anon");
@@ -14,14 +18,10 @@ serve(async (req) => {
     .order("price", { ascending: true });
 
   if (error) {
-    return new Response(
-      JSON.stringify({ ok: false, error: error.message }),
-      { status: 500 },
-    );
+    return oops(error.message);
   }
 
-  return new Response(
-    JSON.stringify({ ok: true, plans: data }),
-    { headers: { "content-type": "application/json" } },
-  );
-});
+  return ok({ plans: data });
+}
+
+if (import.meta.main) serve(handler);

--- a/supabase/functions/promo-validate/index.ts
+++ b/supabase/functions/promo-validate/index.ts
@@ -1,12 +1,17 @@
-// >>> DC BLOCK: promo-validate-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { requireEnv } from "../_shared/env.ts";
 import { calcFinalAmount } from "../_shared/promo.ts";
+import { bad, json, mna, ok } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
+  const v = version(req, "promo-validate");
+  if (v) return v;
+  if (req.method !== "POST") return mna();
+
   const { code, telegram_id, plan_id } = await req.json().catch(() => ({}));
   if (!code || !telegram_id || !plan_id) {
-    return new Response(JSON.stringify({ ok: false, error: "bad_request" }), { status: 400 });
+    return bad("bad_request");
   }
 
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
@@ -18,7 +23,6 @@ serve(async (req) => {
     "content-type": "application/json",
   };
 
-  // validate via RPC
   const vr = await fetch(`${SUPABASE_URL}/rest/v1/rpc/validate_promo_code`, {
     method: "POST",
     headers,
@@ -26,13 +30,9 @@ serve(async (req) => {
   });
   const [res] = await vr.json();
   if (!res?.valid) {
-    return new Response(JSON.stringify({ ok: false, reason: res?.reason || "invalid" }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return json({ ok: false, reason: res?.reason || "invalid" }, 200);
   }
 
-  // fetch plan price
   const pr = await fetch(
     `${SUPABASE_URL}/rest/v1/subscription_plans?id=eq.${plan_id}&select=price`,
     { headers },
@@ -41,14 +41,11 @@ serve(async (req) => {
   const price = plan?.[0]?.price || 0;
   const final_amount = calcFinalAmount(price, res.discount_type, res.discount_value);
 
-  return new Response(
-    JSON.stringify({
-      ok: true,
-      type: res.discount_type,
-      value: res.discount_value,
-      final_amount,
-    }),
-    { headers: { "content-type": "application/json" } },
-  );
-});
-// <<< DC BLOCK: promo-validate-core (end)
+  return ok({
+    type: res.discount_type,
+    value: res.discount_value,
+    final_amount,
+  });
+}
+
+if (import.meta.main) serve(handler);

--- a/supabase/functions/referral-link/index.ts
+++ b/supabase/functions/referral-link/index.ts
@@ -1,18 +1,26 @@
-// >>> DC BLOCK: referral-link-core (start)
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { requireEnv } from "../_shared/env.ts";
+import { bad, ok, mna } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
 export function makeReferralLink(username: string, id: string | number): string {
   return `https://t.me/${username}?startapp=ref_${id}`;
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
+  const v = version(req, "referral-link");
+  if (v) return v;
+  if (req.method !== "POST") return mna();
+
   const { telegram_id } = await req.json().catch(() => ({}));
   if (!telegram_id) {
-    return new Response(JSON.stringify({ ok: false, error: "bad_request" }), { status: 400 });
+    return bad("bad_request");
   }
-  const { TELEGRAM_BOT_USERNAME } = requireEnv(["TELEGRAM_BOT_USERNAME"] as const);
+  const { TELEGRAM_BOT_USERNAME } = requireEnv([
+    "TELEGRAM_BOT_USERNAME",
+  ] as const);
   const link = makeReferralLink(TELEGRAM_BOT_USERNAME, telegram_id);
-  return new Response(JSON.stringify({ ok: true, link }), { headers: { "content-type": "application/json" } });
-});
-// <<< DC BLOCK: referral-link-core (end)
+  return ok({ link });
+}
+
+if (import.meta.main) serve(handler);

--- a/supabase/functions/setup-webhook-helper/index.ts
+++ b/supabase/functions/setup-webhook-helper/index.ts
@@ -1,25 +1,29 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { need } from "../_shared/env.ts";
-import { ok, oops } from "../_shared/http.ts";
+import { ok, oops, mna } from "../_shared/http.ts";
 import { ensureWebhookSecret } from "../_shared/telegram_secret.ts";
 import { createClient } from "../_shared/client.ts";
+import { version } from "../_shared/version.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+function withCors(res: Response) {
+  Object.entries(corsHeaders).forEach(([k, v]) => res.headers.set(k, v));
+  return res;
+}
 
-  if (req.method !== 'POST') {
-    return new Response('Method not allowed', { 
-      status: 405,
-      headers: corsHeaders 
-    });
+export async function handler(req: Request): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return withCors(ok());
+  }
+  const v = version(req, "setup-webhook-helper");
+  if (v) return withCors(v);
+  if (req.method !== "POST") {
+    return withCors(mna());
   }
 
   try {
@@ -34,48 +38,39 @@ serve(async (req) => {
     console.log(`Setting up webhook: ${WEBHOOK_URL}`);
     console.log(`Using webhook secret: ${WEBHOOK_SECRET}`);
 
-    // Set webhook with Telegram
     const telegramResponse = await fetch(
       `https://api.telegram.org/bot${BOT_TOKEN}/setWebhook`,
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           url: WEBHOOK_URL,
           secret_token: WEBHOOK_SECRET,
-          drop_pending_updates: true
-        })
-      }
+          drop_pending_updates: true,
+        }),
+      },
     );
 
     const telegramResult = await telegramResponse.json();
-    
+
     if (!telegramResult.ok) {
       console.error("Telegram webhook setup failed:", telegramResult);
-      return oops("Failed to set webhook with Telegram", telegramResult);
+      return withCors(oops("Failed to set webhook with Telegram", telegramResult));
     }
-    const response = ok({
+    return withCors(ok({
       success: true,
       webhook_url: WEBHOOK_URL,
       telegram_response: telegramResult,
       message: "Webhook configured successfully!",
       webhook_secret: WEBHOOK_SECRET,
       instructions: [
-        "If TELEGRAM_WEBHOOK_SECRET is not set in Supabase secrets, add it with the provided value"
-      ]
-    });
-
-    return new Response(response.body, {
-      status: response.status,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
-
+        "If TELEGRAM_WEBHOOK_SECRET is not set in Supabase secrets, add it with the provided value",
+      ],
+    }));
   } catch (error) {
     console.error("Setup webhook error:", error);
-    const response = oops("Failed to setup webhook", { error: error.message });
-    return new Response(response.body, {
-      status: response.status,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
+    return withCors(oops("Failed to setup webhook", { error: (error as Error).message }));
   }
-});
+}
+
+if (import.meta.main) serve(handler);

--- a/supabase/functions/test-bot-status/index.ts
+++ b/supabase/functions/test-bot-status/index.ts
@@ -1,5 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { getEnv } from "../_shared/env.ts";
+import { json, mna } from "../_shared/http.ts";
+import { version } from "../_shared/version.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -7,39 +9,39 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
+    return json({}, 200, corsHeaders);
   }
+  const v = version(req, "test-bot-status");
+  if (v) return v;
+  if (req.method !== "POST") return mna();
 
   try {
     const botToken = getEnv("TELEGRAM_BOT_TOKEN");
 
     console.log("Testing bot status...");
 
-    // 1. Check bot info
     const botInfoResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/getMe`,
     );
     const botInfo = await botInfoResponse.json();
     console.log("Bot info result:", botInfo);
 
-    // 2. Check webhook info
     const webhookResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/getWebhookInfo`,
     );
     const webhookInfo = await webhookResponse.json();
     console.log("Webhook info result:", webhookInfo);
 
-    // 3. Check for pending updates
     const updatesResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/getUpdates?limit=1`,
     );
     const updatesInfo = await updatesResponse.json();
     console.log("Recent updates:", updatesInfo);
 
-    return new Response(
-      JSON.stringify({
+    return json(
+      {
         success: true,
         bot_status: botInfo.ok ? "✅ Bot Active" : "❌ Bot Error",
         bot_info: botInfo.result,
@@ -49,24 +51,22 @@ serve(async (req) => {
         webhook_info: webhookInfo.result,
         pending_updates: updatesInfo.result?.length || 0,
         timestamp: new Date().toISOString(),
-      }),
-      {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 200,
       },
+      200,
+      corsHeaders,
     );
   } catch (error) {
     console.error("Error testing bot:", error);
-    return new Response(
-      JSON.stringify({
-        error: error.message,
+    return json(
+      {
+        error: (error as Error).message,
         success: false,
         timestamp: new Date().toISOString(),
-      }),
-      {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 500,
       },
+      500,
+      corsHeaders,
     );
   }
-});
+}
+
+if (import.meta.main) serve(handler);


### PR DESCRIPTION
## Summary
- add shared `version` helper
- expose `/version` route & HEAD across edge functions
- swap `new Response` for HTTP helper utilities and enforce method checks

## Testing
- `npm test` *(fails: sh: 1: deno: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a7cb36408322a5414a036e06d8a6