### PR TITLE
test: cover webhook auth and config overrides

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -96,7 +96,7 @@ export async function setFlag(name: string, val: boolean): Promise<void> {
 
 // === Bot settings & content helpers ===
 
-async function getSetting<T = unknown>(key: string): Promise<T | null> {
+export let getSetting = async <T = unknown>(key: string): Promise<T | null> => {
   const cached = getCached<T>(`s:${key}`);
   if (cached !== null) return cached;
   const client = getClient();
@@ -114,6 +114,11 @@ async function getSetting<T = unknown>(key: string): Promise<T | null> {
     console.error("Error getting setting:", e);
   }
   return null;
+};
+
+// Test helper to override getSetting
+export function __setGetSetting(fn: typeof getSetting) {
+  getSetting = fn;
 }
 
 async function requireSetting<T = unknown>(key: string): Promise<T> {
@@ -156,7 +161,6 @@ async function getContent<T = unknown>(
 export {
   getConfig,
   setConfig,
-  getSetting,
   requireSetting,
   envOrSetting,
   getContent,

--- a/supabase/functions/_tests/payments-flags.test.ts
+++ b/supabase/functions/_tests/payments-flags.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setConfig, getFlag } from "../_shared/config.ts";
+
+async function applyAutoApprove(payment: { method: string; status: string }) {
+  const flag = await getFlag(`auto_approve_${payment.method}`, false);
+  payment.status = flag ? "completed" : "awaiting_admin";
+}
+
+Deno.test("crypto auto-approval flag", async () => {
+  await setConfig("features:published", { data: { auto_approve_crypto: true } });
+  const p1 = { method: "crypto", status: "pending" };
+  await applyAutoApprove(p1);
+  assertEquals(p1.status, "completed");
+
+  await setConfig("features:published", { data: { auto_approve_crypto: false } });
+  const p2 = { method: "crypto", status: "pending" };
+  await applyAutoApprove(p2);
+  assertEquals(p2.status, "awaiting_admin");
+});
+
+Deno.test("bank transfer auto-approval flag", async () => {
+  await setConfig("features:published", { data: { auto_approve_bank_transfer: true } });
+  const p1 = { method: "bank_transfer", status: "pending" };
+  await applyAutoApprove(p1);
+  assertEquals(p1.status, "completed");
+
+  await setConfig("features:published", { data: { auto_approve_bank_transfer: false } });
+  const p2 = { method: "bank_transfer", status: "pending" };
+  await applyAutoApprove(p2);
+  assertEquals(p2.status, "awaiting_admin");
+});
+
+Deno.test("binance pay auto-approval flag", async () => {
+  await setConfig("features:published", { data: { auto_approve_binance_pay: true } });
+  const p1 = { method: "binance_pay", status: "pending" };
+  await applyAutoApprove(p1);
+  assertEquals(p1.status, "completed");
+
+  await setConfig("features:published", { data: { auto_approve_binance_pay: false } });
+  const p2 = { method: "binance_pay", status: "pending" };
+  await applyAutoApprove(p2);
+  assertEquals(p2.status, "awaiting_admin");
+});

--- a/supabase/functions/_tests/telegram-bot-webhook-security.test.ts
+++ b/supabase/functions/_tests/telegram-bot-webhook-security.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setTestEnv, clearTestEnv } from "./env-mock.ts";
+
+Deno.test("telegram-bot rejects requests without secret", async () => {
+  setTestEnv({
+    TELEGRAM_WEBHOOK_SECRET: "s3cr3t",
+    SUPABASE_URL: "https://example.com",
+    SUPABASE_SERVICE_ROLE_KEY: "srv",
+    TELEGRAM_BOT_TOKEN: "token",
+  });
+  const { default: handler } = await import("../telegram-bot/index.ts");
+  const req = new Request("https://example.com/telegram-bot", {
+    method: "POST",
+    body: "{}",
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 401);
+  clearTestEnv();
+});
+
+Deno.test("telegram-bot accepts valid secret", async () => {
+  setTestEnv({
+    TELEGRAM_WEBHOOK_SECRET: "s3cr3t",
+    SUPABASE_URL: "https://example.com",
+    SUPABASE_SERVICE_ROLE_KEY: "srv",
+    TELEGRAM_BOT_TOKEN: "token",
+  });
+  const { default: handler } = await import("../telegram-bot/index.ts");
+  const req = new Request("https://example.com/telegram-bot", {
+    method: "POST",
+    headers: { "x-telegram-bot-api-secret-token": "s3cr3t" },
+    body: JSON.stringify({ test: "ping" }),
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+  const json = await res.json();
+  assertEquals(json.pong, true);
+  clearTestEnv();
+});
+
+Deno.test("telegram-bot /version endpoint", async () => {
+  const { default: handler } = await import("../telegram-bot/index.ts");
+  const req = new Request("https://example.com/version", { method: "GET" });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+  const json = await res.json();
+  assertEquals(json.name, "telegram-bot");
+});

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1332,6 +1332,7 @@ export async function serveWebhook(req: Request): Promise<Response> {
   }
 }
 
+export default serveWebhook;
 if (import.meta.main) {
   Deno.serve(serveWebhook);
 }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -141,6 +141,7 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 // Start the HTTP server when run as a standalone script in Deno.
+export default handler;
 if (import.meta.main && typeof Deno !== "undefined") {
   // Use a dynamic import so the module can also be loaded in Node tests
   // where the Deno standard library is unavailable.

--- a/tests/config-softcode.test.ts
+++ b/tests/config-softcode.test.ts
@@ -1,0 +1,15 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+Deno.test("envOrSetting prefers env over bot_setting", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.com");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service");
+  const cfg = await import("../supabase/functions/_shared/config.ts");
+  Deno.env.set("EXAMPLE_KEY", "env-value");
+  const original = cfg.getSetting;
+  cfg.__setGetSetting(async () => "db-value");
+  const val = await cfg.envOrSetting("EXAMPLE_KEY", "EXAMPLE_KEY");
+  assertEquals(val, "env-value");
+  cfg.__setGetSetting(original);
+  Deno.env.delete("EXAMPLE_KEY");
+});


### PR DESCRIPTION
## Summary
- add default handlers for telegram-bot and telegram-webhook
- add tests for telegram webhook security, config override, and payment flag behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a9a995c483229fff091bb5841e4c