### PR TITLE
feat: add edge smoke test and deploy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "setup:supabase": "bash scripts/setup-supabase-cli.sh",
     "build:miniapp": "cd miniapp && npm ci && npm run build && rm -rf ../supabase/functions/miniapp/static && mkdir -p ../supabase/functions/miniapp/static && cp -r dist/* ../supabase/functions/miniapp/static",
     "deploy:bot": "npx supabase functions deploy telegram-bot --project-ref $PROJECT_REF",
-    "deploy:edge": "npx supabase functions deploy miniapp telegram-bot binance-pay-checkout binancepay-webhook receipt-submit receipt-ocr crypto-webhook admin-act-on-payment --project-ref qeejuomcapbdlhnjqjcc"
+    "deploy:edge": "npx supabase functions deploy miniapp telegram-bot binance-pay-checkout binancepay-webhook receipt-submit receipt-ocr crypto-webhook admin-act-on-payment --project-ref qeejuomcapbdlhnjqjcc",
+    "edge:deploy:core": "npx supabase functions deploy telegram-bot miniapp --project-ref qeejuomcapbdlhnjqjcc",
+    "edge:deploy:ops": "npx supabase functions deploy payments-auto-review data-retention-cron broadcast-cron subscriptions-cron rotate-webhook-secret --project-ref qeejuomcapbdlhnjqjcc",
+    "edge:smoke": "node scripts/smoke.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1,0 +1,34 @@
+const base = process.env.FUNCTIONS_BASE || (process.env.SUPABASE_PROJECT_REF ? `https://${process.env.SUPABASE_PROJECT_REF}.functions.supabase.co` : null);
+if (!base) {
+  console.error('Set FUNCTIONS_BASE or SUPABASE_PROJECT_REF.');
+  process.exit(1);
+}
+
+async function check(method, path, expected, init = {}) {
+  try {
+    const res = await fetch(base + path, { method, ...init });
+    if (res.status !== expected) {
+      console.error(`[!] ${method} ${path} expected ${expected} got ${res.status}`);
+      return false;
+    }
+    console.log(`[OK] ${method} ${path} -> ${res.status}`);
+    return true;
+  } catch (err) {
+    console.error(`[ERR] ${method} ${path} -> ${err.message}`);
+    return false;
+  }
+}
+
+const results = await Promise.all([
+  check('GET', '/telegram-bot/version', 200),
+  check('POST', '/telegram-bot', 401, {
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  }),
+  check('GET', '/miniapp/version', 200),
+  check('HEAD', '/miniapp', 200),
+]);
+
+if (results.includes(false)) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add deployment scripts for core and ops edge functions
- add smoke test script to verify deployed edge endpoints

## Testing
- `npm test` *(fails: sh: 1: deno: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac47f1c083228525c3904430a1f8