### PR TITLE
Handle missing bot content callbacks

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers/bot-content.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/bot-content.ts
@@ -107,3 +107,77 @@ export async function handleContentManagement(
     );
   }
 }
+
+export async function handleEditContent(
+  chatId: number,
+  _userId: string,
+  contentKey: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_content")
+      .select("content_value")
+      .eq("content_key", contentKey)
+      .maybeSingle();
+    if (error) throw error;
+    const current = data?.content_value ?? "";
+    const msg =
+      `📝 *Editing ${contentKey}*\\n\\nCurrent value:\n${current}\n\nSend new content to update this entry.`;
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_content" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleEditContent:", err);
+    await sendMessage(chatId, "❌ Error preparing content for edit.");
+  }
+}
+
+export async function handleAddNewContent(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const msg =
+      "➕ *Add New Content*\\n\\nSend new content in the format `key=Your content here`.";
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_content" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handleAddNewContent:", err);
+    await sendMessage(chatId, "❌ Error preparing to add content.");
+  }
+}
+
+export async function handlePreviewAllContent(
+  chatId: number,
+  _userId: string,
+): Promise<void> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("bot_content")
+      .select("content_key, content_value")
+      .order("content_key", { ascending: true });
+    if (error) throw error;
+    const lines = (data || []).map(
+      (row: { content_key: string; content_value: string }) =>
+        `• ${row.content_key}: ${row.content_value}`,
+    );
+    const msg = `👀 *All Bot Content*\\n\\n${lines.join("\\n")}`;
+    const keyboard = {
+      inline_keyboard: [[
+        { text: "⬅️ Back", callback_data: "manage_table_bot_content" },
+      ]],
+    };
+    await sendMessage(chatId, msg, keyboard);
+  } catch (err) {
+    console.error("Error in handlePreviewAllContent:", err);
+    await sendMessage(chatId, "❌ Error fetching content preview.");
+  }
+}
+

--- a/supabase/functions/telegram-bot/admin-handlers/index.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/index.ts
@@ -13,7 +13,12 @@ import type {
 
 import { supabaseAdmin, sendMessage } from "./common.ts";
 export { sendMessage } from "./common.ts";
-export { handleContentManagement } from "./bot-content.ts";
+export {
+  handleContentManagement,
+  handleEditContent,
+  handleAddNewContent,
+  handlePreviewAllContent,
+} from "./bot-content.ts";
 export {
   handleBotSettingsManagement,
   handleConfigSessionSettings,

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -518,6 +518,26 @@ export function buildCallbackHandlers(
       handlers.handleBankAccountsManagement(chatId, userId),
     manage_table_auto_reply_templates: (chatId, userId) =>
       handlers.handleAutoReplyTemplatesManagement(chatId, userId),
+    edit_content_welcome_message: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "welcome_message"),
+    edit_content_about_us: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "about_us"),
+    edit_content_support_message: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "support_message"),
+    edit_content_terms_conditions: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "terms_conditions"),
+    edit_content_faq_general: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "faq_general"),
+    edit_content_maintenance_message: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "maintenance_message"),
+    edit_content_vip_benefits: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "vip_benefits"),
+    edit_content_payment_instructions: (chatId, userId) =>
+      handlers.handleEditContent(chatId, userId, "payment_instructions"),
+    add_new_content: (chatId, userId) =>
+      handlers.handleAddNewContent(chatId, userId),
+    preview_all_content: (chatId, userId) =>
+      handlers.handlePreviewAllContent(chatId, userId),
     export_all_tables: (chatId, userId) =>
       handlers.handleExportAllTables(chatId, userId),
     table_stats_overview: (chatId, userId) =>


### PR DESCRIPTION
## Summary
- add handlers for editing, adding, and previewing bot content
- wire new handlers into admin callback map
- export handlers from admin-handlers index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b784d30c8322987a931b1ae541fc