### PR TITLE
feat: expand telegram start menu

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -863,6 +863,20 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
       await editMessage(chatId, cb.message!.message_id!, view.text, view.extra);
       return;
     }
+    if (data.startsWith("cmd:")) {
+      const cmd = "/" + data.slice("cmd:".length);
+      const handler = commandHandlers[cmd] ?? adminCommandHandlers[cmd];
+      if (handler) {
+        const ctx: CommandContext = {
+          msg: cb.message ?? { chat: { id: chatId } },
+          chatId,
+          args: [],
+          miniAppValid: await hasMiniApp(),
+        };
+        await handler(ctx);
+      }
+      return;
+    }
     if (data.startsWith("buy:")) {
       const planId = data.slice("buy:".length);
       const pkgs = await getVipPackages();

--- a/supabase/functions/telegram-bot/menu.ts
+++ b/supabase/functions/telegram-bot/menu.ts
@@ -2,19 +2,34 @@ export type MenuSection = "dashboard" | "plans" | "support";
 
 export function buildMainMenu(section: MenuSection) {
   return {
-    inline_keyboard: [[
-      {
-        text: `${section === "dashboard" ? "✅ " : ""}Dashboard`,
-        callback_data: "nav:dashboard",
-      },
-      {
-        text: `${section === "plans" ? "✅ " : ""}Plans`,
-        callback_data: "nav:plans",
-      },
-      {
-        text: `${section === "support" ? "✅ " : ""}Support`,
-        callback_data: "nav:support",
-      },
-    ]],
+    inline_keyboard: [
+      [
+        {
+          text: `${section === "dashboard" ? "✅ " : ""}Dashboard`,
+          callback_data: "nav:dashboard",
+        },
+        {
+          text: `${section === "plans" ? "✅ " : ""}Plans`,
+          callback_data: "nav:plans",
+        },
+        {
+          text: `${section === "support" ? "✅ " : ""}Support`,
+          callback_data: "nav:support",
+        },
+      ],
+      [
+        { text: "Packages", callback_data: "cmd:packages" },
+        { text: "Promo", callback_data: "cmd:promo" },
+        { text: "Account", callback_data: "cmd:account" },
+      ],
+      [
+        { text: "FAQ", callback_data: "cmd:faq" },
+        { text: "Education", callback_data: "cmd:education" },
+      ],
+      [
+        { text: "Ask", callback_data: "cmd:ask" },
+        { text: "Should I Buy?", callback_data: "cmd:shouldibuy" },
+      ],
+    ],
   };
 }


### PR DESCRIPTION
## Summary
- show extra bot command options in start menu
- handle command buttons via callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bac160f4832296a94d54794feb3b