### PR TITLE
Conditionally render logout button in miniapp TopBar

### DIFF
--- a/supabase/functions/miniapp/src/components/TopBar.tsx
+++ b/supabase/functions/miniapp/src/components/TopBar.tsx
@@ -9,7 +9,9 @@ export default function TopBar({ title, onLogout }: Props) {
   return (
     <div className="mb-4 flex items-center justify-between">
       <h1 className="text-lg font-semibold">{title}</h1>
-      <SecondaryButton label="Log out" onClick={onLogout} />
+      {onLogout && (
+        <SecondaryButton label="Log out" onClick={onLogout} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Render the TopBar's "Log out" button only when a logout handler is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22944054883229a3075d85e8b4c73