### PR TITLE
Revoke object URLs in receipt uploader

### DIFF
--- a/supabase/functions/miniapp/src/components/ReceiptUploader.tsx
+++ b/supabase/functions/miniapp/src/components/ReceiptUploader.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 interface Props {
   onChange: (file: File | null) => void;
@@ -9,10 +9,22 @@ export default function ReceiptUploader({ onChange }: Props) {
 
   function handle(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0] || null;
+
+    // Revoke previous object URL to avoid memory leaks
+    if (preview) URL.revokeObjectURL(preview);
+
     onChange(file);
+
     if (file) setPreview(URL.createObjectURL(file));
     else setPreview("");
   }
+
+  // Clean up object URL when component unmounts or preview changes
+  useEffect(() => {
+    return () => {
+      if (preview) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- revoke previous object URLs when selecting new receipt file
- clean up object URLs when component unmounts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a22944c42883228cf3a65dac0dd94b