### PR TITLE
refactor: remove legacy x-frame-options

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -13,7 +13,6 @@ export const DEFAULT_SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-content-type-options": "nosniff",
   "permissions-policy": "geolocation=(), microphone=(), camera=()",
-  "x-frame-options": "SAMEORIGIN",
   "content-security-policy":
     "default-src 'self' https://*.telegram.org https://telegram.org; " +
     "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
@@ -21,7 +20,7 @@ export const DEFAULT_SECURITY = {
     "img-src 'self' data: https:; " +
     "connect-src 'self' https://*.functions.supabase.co https://*.supabase.co wss://*.supabase.co; " +
     "font-src 'self' data:; " +
-    "frame-ancestors *;",
+    "frame-ancestors 'self';",
 } as const;
 
 function mime(p: string) {

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -5,7 +5,14 @@ export function handler(req: Request): Promise<Response> {
     rootDir: new URL("./static/", import.meta.url),
     spaRoots: ["/", "/miniapp"],
     security: {
-      "x-frame-options": "ALLOWALL",
+      "content-security-policy":
+        "default-src 'self' https://*.telegram.org https://telegram.org; " +
+        "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
+        "style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data: https:; " +
+        "connect-src 'self' https://*.functions.supabase.co https://*.supabase.co wss://*.supabase.co; " +
+        "font-src 'self' data:; " +
+        "frame-ancestors 'self' https://*.t.me https://*.telegram.org https://web.telegram.org https://telegram.org;",
       "strict-transport-security":
         "max-age=63072000; includeSubDomains; preload",
     },


### PR DESCRIPTION
## Summary
- rely on CSP `frame-ancestors` instead of legacy `x-frame-options`
- tighten default security headers to use `frame-ancestors 'self'`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a229430a308322bd65a4001f4a7da7