### PR TITLE
test: add webhook secret validation tests

### DIFF
--- a/functions/_tests/webhook-secret.test.ts
+++ b/functions/_tests/webhook-secret.test.ts
@@ -1,0 +1,44 @@
+// functions/_tests/webhook-secret.test.ts
+// Test validation of x-telegram-bot-api-secret-token header for telegram-webhook.
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { setTestEnv, clearTestEnv } from "../../supabase/functions/_tests/env-mock.ts";
+
+// Provide minimal environment so the handler module can load without reaching for
+// real secrets or network resources.
+setTestEnv({
+  SUPABASE_URL: "http://local",
+  SUPABASE_ANON_KEY: "anon",
+  SUPABASE_SERVICE_ROLE_KEY: "service",
+  TELEGRAM_BOT_TOKEN: "test-token",
+  TELEGRAM_WEBHOOK_SECRET: "test-secret",
+});
+
+const mod = await import("../../supabase/functions/telegram-webhook/index.ts");
+const handler: (req: Request) => Promise<Response> = mod.default ?? mod.handler;
+
+Deno.test("accepts valid webhook secret", async () => {
+  const req = new Request("http://local/telegram-webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-telegram-bot-api-secret-token": "test-secret",
+    },
+    body: "{}",
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+});
+
+Deno.test("rejects invalid webhook secret", async () => {
+  const req = new Request("http://local/telegram-webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-telegram-bot-api-secret-token": "wrong-secret",
+    },
+    body: "{}",
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 401);
+  clearTestEnv();
+});


### PR DESCRIPTION
## Summary
- add tests for `telegram-webhook` verifying valid secret tokens return 200 and invalid tokens are rejected with 401

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22e06d0f48322ba070443855c2fd0