### PR TITLE
docs: document secret-token validation

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,6 +42,15 @@ curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
   -d "secret_token=$TELEGRAM_WEBHOOK_SECRET"
 ```
 
+### Secret-token validation
+
+- Telegram echoes the `secret_token` as `X-Telegram-Bot-Api-Secret-Token` on
+  each webhook call.
+- The Edge function compares this header to `TELEGRAM_WEBHOOK_SECRET` and
+  returns `401` on mismatch.
+- See [Telegram setWebhook docs](https://core.telegram.org/bots/api#setwebhook)
+  for details.
+
 ## Troubleshooting
 
 ### Resetting bot token

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -53,4 +53,12 @@ curl "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
 curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getWebhookInfo"
 ```
 
+### Secret-token validation
+
+- Telegram includes `X-Telegram-Bot-Api-Secret-Token` on each webhook request.
+- The bot compares this header to `TELEGRAM_WEBHOOK_SECRET` and rejects
+  mismatches with `401`.
+- See [Telegram setWebhook docs](https://core.telegram.org/bots/api#setwebhook)
+  for more info.
+
 Note: /start shows Mini App button (short_name preferred, URL fallback).

--- a/docs/REPO_SUMMARY.md
+++ b/docs/REPO_SUMMARY.md
@@ -7,6 +7,7 @@
 ## 1) High-Level Overview
 - Tech stack: Deno, Supabase Edge Functions, Postgres (Supabase), Telegram Bot.
 - Primary domains: bot automation (Telegram), subscriptions/payments, analytics, broadcasts.
+- `X-Frame-Options` header removed to allow embedding in Telegram.
 
 ## 2) Directory Map (top-level)
 ```

--- a/docs/RUNBOOK_start-not-responding.md
+++ b/docs/RUNBOOK_start-not-responding.md
@@ -41,6 +41,20 @@ supabase secrets get TELEGRAM_BOT_TOKEN
 - An empty value means the Edge function cannot reply to messages. Set it with
   `supabase secrets set TELEGRAM_BOT_TOKEN=...`.
 
+### Secret-token validation failures
+
+- Verify the secret expected by the function:
+
+  ```bash
+  supabase secrets get TELEGRAM_WEBHOOK_SECRET
+  ```
+
+- Re-run `setWebhook` with the same value. Telegram sends this back as
+  `X-Telegram-Bot-Api-Secret-Token`; mismatches return `401`.
+- If compromised, rotate via `supabase functions deploy rotate-webhook-secret`
+  and update your Edge secrets.
+- Telegram docs: https://core.telegram.org/bots/api#setwebhook
+
 ## Common causes
 
 - Wrong or missing `X-Telegram-Bot-Api-Secret-Token` header.

--- a/docs/TELEGRAM_WEBHOOK_KEEPER.md
+++ b/docs/TELEGRAM_WEBHOOK_KEEPER.md
@@ -1,6 +1,12 @@
 - Secret precedence: ENV -> DB -> auto-generate.
 - If auto-generated, it is stored at public.bot_settings
   (key=TELEGRAM_WEBHOOK_SECRET).
-- The bot validates the header against either ENV or DB value.
 - For maximum resilience, you can later mirror the DB value into Edge secrets
   via CLI: npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<value>
+
+## Secret-token validation
+
+- When calling [setWebhook](https://core.telegram.org/bots/api#setwebhook), supply
+  `secret_token` so Telegram signs requests.
+- Telegram then includes `X-Telegram-Bot-Api-Secret-Token`; the keeper compares
+  this header to the stored secret and replies `401` on mismatch.


### PR DESCRIPTION
## Summary
- explain secret-token validation for Telegram webhooks and link to Telegram docs
- note removal of X-Frame-Options header for Telegram embedding
- add runbook tips for troubleshooting secret-token failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22e05f0ac832284fbc349161e857d