### PR TITLE
feat: expose mini app button on /start

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,11 +24,14 @@ below.
 | FOLLOW_UP_DELAY_MINUTES   | ✅                           | ✅                               | ❌                          |
 | MAX_FOLLOW_UPS            | ✅                           | ✅                               | ❌                          |
 | MINI_APP_URL              | ✅                           | ✅                               | ✅                          |
+| MINI_APP_SHORT_NAME       | ✅                           | ✅                               | ✅                          |
 | LOGTAIL_SOURCE_TOKEN      | ✅                           | ❌                               | ❌                          |
 
 `✅` indicates where each key should be set.
 
-`MINI_APP_URL` should point to the deployed Telegram Mini App (for example,
-`https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/`). If set, the bot
-shows a Mini App button and will automatically append a trailing slash if
-missing to avoid redirect issues.
+Either `MINI_APP_URL` or `MINI_APP_SHORT_NAME` must be set for the `/start`
+command to show an **Open Mini App** button. If neither is configured, the bot
+logs a warning and omits the button. `MINI_APP_URL` should point to the deployed
+Telegram Mini App (for example,
+`https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/`) and will
+automatically append a trailing slash if missing to avoid redirect issues.

--- a/docs/MINI_APP_URL_SETUP.md
+++ b/docs/MINI_APP_URL_SETUP.md
@@ -1,9 +1,10 @@
 # MINI_APP_URL setup (Supabase Edge)
 
-## Why you see “Mini app not configured yet”
+## Why you see “Mini app not configured yet” or no button
 
-The bot didn’t find `MINI_APP_URL` or `MINI_APP_SHORT_NAME` (or your function
-wasn’t redeployed after setting them).
+The bot didn’t find `MINI_APP_URL` or `MINI_APP_SHORT_NAME`, or your function
+wasn’t redeployed after setting them. When missing, `/start` logs a warning and
+skips the **Open Mini App** button.
 
 ## Steps (prod)
 
@@ -11,11 +12,11 @@ wasn’t redeployed after setting them).
 
    ```bash
    npx supabase login
-   npx supabase link --project-ref <PROJECT_REF>
-   # Provide either a full URL or a short name
-   npx supabase secrets set MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
-   # or
-   # npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
+ npx supabase link --project-ref <PROJECT_REF>
+  # Provide either a full URL or a short name
+  npx supabase secrets set MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
+  # or
+  # npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
    npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
    npx supabase secrets set TELEGRAM_BOT_TOKEN=<token>
    ```
@@ -39,11 +40,13 @@ wasn’t redeployed after setting them).
 4. Sanity:
 
    ```bash
-   deno run -A scripts/assert-miniapp-config.ts
-   ```
+ deno run -A scripts/assert-miniapp-config.ts
+  ```
 
 Notes:
 
 - Use a trailing slash in `MINI_APP_URL` to avoid redirects in Telegram.
+- If `/start` still lacks the button, confirm the secret is set and the
+  function redeployed; check Supabase logs for the warning above.
 - Keep all runtime secrets in **Supabase Edge**. CI can have `MINI_APP_URL` too
   if your workflows read it, but the bot reads Edge values.

--- a/supabase/functions/_tests/start-command.test.ts
+++ b/supabase/functions/_tests/start-command.test.ts
@@ -1,0 +1,85 @@
+import {
+  assert,
+  assertFalse,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { setTestEnv, clearTestEnv } from "./env-mock.ts";
+
+async function importBot() {
+  // Bust module cache to allow different env per test
+  return await import(`../telegram-bot/index.ts?cache=${crypto.randomUUID()}`);
+}
+
+Deno.test("start command includes Mini App button when env present", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://example.com",
+    SUPABASE_ANON_KEY: "anon",
+    SUPABASE_SERVICE_ROLE_KEY: "srv",
+  });
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "token");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+  Deno.env.set("MINI_APP_URL", "https://mini.example.com/");
+
+  const calls: { input: string; body: string }[] = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = typeof init?.body === "string"
+      ? init.body
+      : init?.body
+      ? JSON.stringify(init.body)
+      : "";
+    calls.push({ input: String(input), body });
+    return new Response("[]", { status: 200 });
+  };
+
+  const { commandHandlers } = await importBot();
+  await commandHandlers["/start"]({ chatId: 1 });
+
+  const sendCalls = calls.filter((c) => c.input.includes("/sendMessage"));
+  const hasButton = sendCalls.some((c) =>
+    c.body.includes("\"web_app\"") || c.body.includes("\"url\"")
+  );
+  assert(hasButton);
+
+  globalThis.fetch = origFetch;
+  clearTestEnv();
+  Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  Deno.env.delete("TELEGRAM_BOT_USERNAME");
+  Deno.env.delete("MINI_APP_URL");
+});
+
+Deno.test("start command omits Mini App button when env missing", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://example.com",
+    SUPABASE_ANON_KEY: "anon",
+    SUPABASE_SERVICE_ROLE_KEY: "srv",
+  });
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "token");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+
+  const calls: { input: string; body: string }[] = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = typeof init?.body === "string"
+      ? init.body
+      : init?.body
+      ? JSON.stringify(init.body)
+      : "";
+    calls.push({ input: String(input), body });
+    return new Response("[]", { status: 200 });
+  };
+
+  const { commandHandlers } = await importBot();
+  await commandHandlers["/start"]({ chatId: 1 });
+
+  const sendCalls = calls.filter((c) => c.input.includes("/sendMessage"));
+  const hasButton = sendCalls.some((c) =>
+    c.body.includes("\"web_app\"") || c.body.includes("\"url\"")
+  );
+  assertFalse(hasButton);
+
+  globalThis.fetch = origFetch;
+  clearTestEnv();
+  Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  Deno.env.delete("TELEGRAM_BOT_USERNAME");
+});
+

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -829,6 +829,19 @@ async function storeReceiptImage(
 
 export const commandHandlers: Record<string, CommandHandler> = {
   "/start": async ({ chatId }) => {
+    const { url, short, ready } = await readMiniAppEnv();
+    if (ready) {
+      const btnText = await getContent("miniapp_button_text") ??
+        "Open VIP Mini App";
+      const prompt = await getContent("miniapp_open_prompt") ??
+        "Join the VIP Mini App:";
+      const markup = url
+        ? { reply_markup: { inline_keyboard: [[{ text: btnText, web_app: { url } }]] } }
+        : { reply_markup: { inline_keyboard: [[{ text: btnText, url: `https://t.me/${botUsername}/${short}` }]] } };
+      await sendMessage(chatId, prompt, markup);
+    } else {
+      console.warn("Mini app not configured; start button omitted");
+    }
     await showMainMenu(chatId, "dashboard");
   },
   "/app": async ({ chatId }) => {


### PR DESCRIPTION
## Summary
- show “Open Mini App” button in /start using MINI_APP_URL or MINI_APP_SHORT_NAME
- warn when mini app config missing and document setup
- test start command for button visibility based on env vars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22e0359f483228308e715698b03d3