### PR TITLE
feat: validate miniapp env

### DIFF
--- a/functions/_tests/start-command.test.ts
+++ b/functions/_tests/start-command.test.ts
@@ -17,13 +17,14 @@ import {
 } from "../../supabase/functions/_tests/env-mock.ts";
 
 // Minimal env for the handler; tests should NEVER need real secrets
-setTestEnv({
-  SUPABASE_URL: "http://local",
-  SUPABASE_ANON_KEY: "test-anon",
-  SUPABASE_SERVICE_ROLE_KEY: "test-svc",
-  TELEGRAM_BOT_TOKEN: "test-token",
-  TELEGRAM_WEBHOOK_SECRET: "test-secret",
-});
+  setTestEnv({
+    SUPABASE_URL: "http://local",
+    SUPABASE_ANON_KEY: "test-anon",
+    SUPABASE_SERVICE_ROLE_KEY: "test-svc",
+    TELEGRAM_BOT_TOKEN: "test-token",
+    TELEGRAM_WEBHOOK_SECRET: "test-secret",
+    MINI_APP_URL: "https://example.com/",
+  });
 
 // Try common paths without modifying existing files:
 const candidates = [

--- a/supabase/functions/_tests/miniapp_health_test.ts
+++ b/supabase/functions/_tests/miniapp_health_test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals, assertThrows } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { FakeSupa } from "./helpers.ts";
+import { requireMiniAppEnv } from "../telegram-bot/helpers/require-env.ts";
 
 Deno.test("miniapp-health: null when user not found", async () => {
   Deno.env.set("SUPABASE_URL", "https://example.com");
@@ -10,4 +11,24 @@ Deno.test("miniapp-health: null when user not found", async () => {
   const supa = FakeSupa() as unknown as SupabaseLike;
   const vip = await getVipForTelegram(supa, "2255");
   assertEquals(vip, null);
+});
+
+Deno.test("requireMiniAppEnv: throws when both MINI_APP_URL and MINI_APP_SHORT_NAME missing", () => {
+  Deno.env.delete("MINI_APP_URL");
+  Deno.env.delete("MINI_APP_SHORT_NAME");
+  assertThrows(() => requireMiniAppEnv());
+});
+
+Deno.test("requireMiniAppEnv: passes when MINI_APP_URL set", () => {
+  Deno.env.set("MINI_APP_URL", "https://example.com/");
+  Deno.env.delete("MINI_APP_SHORT_NAME");
+  requireMiniAppEnv();
+  Deno.env.delete("MINI_APP_URL");
+});
+
+Deno.test("requireMiniAppEnv: passes when MINI_APP_SHORT_NAME set", () => {
+  Deno.env.delete("MINI_APP_URL");
+  Deno.env.set("MINI_APP_SHORT_NAME", "short");
+  requireMiniAppEnv();
+  Deno.env.delete("MINI_APP_SHORT_NAME");
 });

--- a/supabase/functions/_tests/telegram-bot-webhook-security.test.ts
+++ b/supabase/functions/_tests/telegram-bot-webhook-security.test.ts
@@ -7,6 +7,7 @@ Deno.test("telegram-bot rejects requests without secret", async () => {
     SUPABASE_URL: "https://example.com",
     SUPABASE_SERVICE_ROLE_KEY: "srv",
     TELEGRAM_BOT_TOKEN: "token",
+    MINI_APP_URL: "https://example.com/",
   });
   const { default: handler } = await import("../telegram-bot/index.ts");
   const req = new Request("https://example.com/telegram-bot", {
@@ -24,6 +25,7 @@ Deno.test("telegram-bot accepts valid secret", async () => {
     SUPABASE_URL: "https://example.com",
     SUPABASE_SERVICE_ROLE_KEY: "srv",
     TELEGRAM_BOT_TOKEN: "token",
+    MINI_APP_URL: "https://example.com/",
   });
   const { default: handler } = await import("../telegram-bot/index.ts");
   const req = new Request("https://example.com/telegram-bot", {

--- a/supabase/functions/telegram-bot/helpers/require-env.ts
+++ b/supabase/functions/telegram-bot/helpers/require-env.ts
@@ -6,3 +6,11 @@ export function requireEnv(
   const missing = keys.filter((k) => !optionalEnv(k as EnvKey));
   return { ok: missing.length === 0, missing };
 }
+
+export function requireMiniAppEnv(): void {
+  const hasUrl = !!optionalEnv("MINI_APP_URL");
+  const hasShort = !!optionalEnv("MINI_APP_SHORT_NAME");
+  if (!hasUrl && !hasShort) {
+    throw new Error("MINI_APP_URL or MINI_APP_SHORT_NAME must be set");
+  }
+}

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1,5 +1,8 @@
 import { optionalEnv } from "../_shared/env.ts";
-import { requireEnv as requireEnvCheck } from "./helpers/require-env.ts";
+import {
+  requireEnv as requireEnvCheck,
+  requireMiniAppEnv,
+} from "./helpers/require-env.ts";
 import { alertAdmins } from "../_shared/alerts.ts";
 import { json, mna, ok, oops } from "../_shared/http.ts";
 import { validateTelegramHeader } from "../_shared/telegram_secret.ts";
@@ -1318,6 +1321,14 @@ export async function serveWebhook(req: Request): Promise<Response> {
     if (!envOk) {
       console.error("Missing env vars", missing);
       return oops("Missing env vars", missing);
+    }
+
+    try {
+      requireMiniAppEnv();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("Mini app env missing", msg);
+      return oops(msg);
     }
 
     const body = await extractTelegramUpdate(req);

--- a/tests/bot-single-card-nav.test.ts
+++ b/tests/bot-single-card-nav.test.ts
@@ -5,20 +5,22 @@ const supaState: any = { tables: { } };
 
 function setEnv() {
   Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
-  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
-  Deno.env.set("SUPABASE_URL", "http://local");
-  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
-  Deno.env.set("SUPABASE_ANON_KEY", "anon");
+    Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+    Deno.env.set("SUPABASE_URL", "http://local");
+    Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+    Deno.env.set("SUPABASE_ANON_KEY", "anon");
+    Deno.env.set("MINI_APP_URL", "https://example.com/");
 }
 
 function cleanup() {
   Deno.env.delete("TELEGRAM_BOT_TOKEN");
   Deno.env.delete("TELEGRAM_WEBHOOK_SECRET");
-  Deno.env.delete("SUPABASE_URL");
-  Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
-  Deno.env.delete("SUPABASE_ANON_KEY");
-  supaState.tables = {};
-}
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("SUPABASE_ANON_KEY");
+    Deno.env.delete("MINI_APP_URL");
+    supaState.tables = {};
+  }
 
 Deno.test("callback edits message instead of sending new one", async () => {
   setEnv();


### PR DESCRIPTION
## Summary
- require mini app config before processing telegram bot webhooks
- add tests ensuring mini app env validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22e0488888322b44bb4090e2c2800