### PR TITLE
Add miniapp smoke checks for function endpoints

### DIFF
--- a/scripts/smoke-miniapp.ts
+++ b/scripts/smoke-miniapp.ts
@@ -9,6 +9,12 @@
  *   FUNCTIONS_BASE=https://xyz.functions.supabase.co deno run -A scripts/smoke-miniapp.ts
  *
  * Performs simple HTTP requests and prints the status codes.
+ *
+ * Expected output (all status codes 200):
+ *   HEAD /miniapp/ -> 200
+ *   GET /miniapp/version -> 200
+ *   HEAD /functions/v1/miniapp/ -> 200
+ *   GET /functions/v1/miniapp/version -> 200
  */
 
 const base = Deno.env.get("FUNCTIONS_BASE");
@@ -17,14 +23,30 @@ if (!base) {
   Deno.exit(1);
 }
 
-async function check(path: string, init?: RequestInit) {
+let failed = false;
+
+async function check(path: string, init?: RequestInit, failOnError = false) {
   try {
     const res = await fetch(`${base}${path}`, init);
-    console.log(`${init?.method ?? "GET"} ${path} ->`, res.status);
+    const msg = `${init?.method ?? "GET"} ${path} -> ${res.status}`;
+    if (res.status !== 200 && failOnError) {
+      failed = true;
+      console.error(msg, "(expected 200)");
+    } else {
+      console.log(msg);
+    }
   } catch (err) {
+    if (failOnError) failed = true;
     console.error(`${init?.method ?? "GET"} ${path} -> error`, err);
   }
 }
 
 await check("/miniapp/", { method: "HEAD" });
 await check("/miniapp/version");
+await check("/functions/v1/miniapp/", { method: "HEAD" }, true);
+await check("/functions/v1/miniapp/version", undefined, true);
+
+if (failed) {
+  console.error("One or more checks failed.");
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary
- add HEAD and version checks for `/functions/v1/miniapp` endpoints
- fail fast when prefixed checks return non-200 responses
- document expected smoke test output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3f21cf70c8322bfd9ad1d479f76a4