### PR TITLE
fix: enable crypto payments and currency selection

### DIFF
--- a/supabase/functions/crypto-txid/index.ts
+++ b/supabase/functions/crypto-txid/index.ts
@@ -6,7 +6,7 @@ import { bad, mna, ok, unauth } from "../_shared/http.ts";
 serve(async (req) => {
   if (req.method !== "POST") return mna();
 
-  let body: { initData?: string; txid?: string };
+  let body: { initData?: string; txid?: string; amount?: number; currency?: string };
   try {
     body = await req.json();
   } catch {
@@ -24,11 +24,29 @@ serve(async (req) => {
   }
 
   if (supa && body.txid) {
+    let userId: string | undefined;
+    const { data: bu } = await supa
+      .from("bot_users")
+      .select("id")
+      .eq("telegram_id", String(u.id))
+      .limit(1);
+    userId = bu?.[0]?.id as string | undefined;
+    if (!userId) {
+      const { data: ins } = await supa
+        .from("bot_users")
+        .insert({ telegram_id: String(u.id) })
+        .select("id")
+        .single();
+      userId = ins?.id as string | undefined;
+    }
+    const currency = body.currency === "MVR" ? "MVR" : "USD";
+    const baseAmount = body.amount || 0;
+    const expected = currency === "MVR" ? baseAmount * 17.5 : baseAmount;
     const { error } = await supa.from("payment_intents").insert({
-      user_id: crypto.randomUUID(),
+      user_id: userId ?? crypto.randomUUID(),
       method: "crypto",
-      expected_amount: 0,
-      currency: "USD",
+      expected_amount: expected,
+      currency,
       status: "pending",
       notes: body.txid,
     });

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -466,4 +466,10 @@ async function handler(req: Request): Promise<Response> {
   });
 }
 
-Deno.serve(handler);
+// Only start the server when executed directly, so tests can import the handler
+// without side effects like binding to a port.
+if (import.meta.main) {
+  Deno.serve(handler);
+}
+
+export default handler;


### PR DESCRIPTION
## Summary
- fix crypto txid endpoint to link to real bot user and support currency amounts
- allow payment intents in USD or MVR with auto conversion
- prompt Telegram bot users to choose USD or MVR before creating payments

## Testing
- `npm test` *(fails: miniapp-edge-host-routing.test.ts missing default export)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69b14a10083228363e9f4117443f6