### PR TITLE
Fix promo code validation using user ID

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -984,7 +984,7 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         {
           method: "POST",
           headers,
-          body: JSON.stringify({ code, telegram_id: chatId, plan_id: planId }),
+          body: JSON.stringify({ code, telegram_id: userId, plan_id: planId }),
         },
       ).then((r) => r.json()).catch(() => null);
       if (!resp?.ok) {


### PR DESCRIPTION
## Summary
- ensure Telegram bot promo validation uses the user's ID instead of chat ID

## Testing
- `deno test --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check`


------
https://chatgpt.com/codex/tasks/task_e_68a71d65aae08322a22ccb9902a02558