### PR TITLE
feat: add icons to telegram menu

### DIFF
--- a/supabase/functions/telegram-bot/menu.ts
+++ b/supabase/functions/telegram-bot/menu.ts
@@ -5,30 +5,30 @@ export function buildMainMenu(section: MenuSection) {
     inline_keyboard: [
       [
         {
-          text: `${section === "dashboard" ? "✅ " : ""}Dashboard`,
+          text: `${section === "dashboard" ? "✅ " : ""}📊 Dashboard`,
           callback_data: "nav:dashboard",
         },
         {
-          text: `${section === "plans" ? "✅ " : ""}Plans`,
+          text: `${section === "plans" ? "✅ " : ""}💳 Plans`,
           callback_data: "nav:plans",
         },
         {
-          text: `${section === "support" ? "✅ " : ""}Support`,
+          text: `${section === "support" ? "✅ " : ""}💬 Support`,
           callback_data: "nav:support",
         },
       ],
       [
-        { text: "Packages", callback_data: "cmd:packages" },
-        { text: "Promo", callback_data: "cmd:promo" },
-        { text: "Account", callback_data: "cmd:account" },
+        { text: "📦 Packages", callback_data: "cmd:packages" },
+        { text: "🎁 Promo", callback_data: "cmd:promo" },
+        { text: "👤 Account", callback_data: "cmd:account" },
       ],
       [
-        { text: "FAQ", callback_data: "cmd:faq" },
-        { text: "Education", callback_data: "cmd:education" },
+        { text: "❓ FAQ", callback_data: "cmd:faq" },
+        { text: "📚 Education", callback_data: "cmd:education" },
       ],
       [
-        { text: "Ask", callback_data: "cmd:ask" },
-        { text: "Should I Buy?", callback_data: "cmd:shouldibuy" },
+        { text: "🤖 Ask", callback_data: "cmd:ask" },
+        { text: "💡 Should I Buy?", callback_data: "cmd:shouldibuy" },
       ],
     ],
   };

--- a/tests/main-menu.test.ts
+++ b/tests/main-menu.test.ts
@@ -3,10 +3,10 @@ import { buildMainMenu } from "../supabase/functions/telegram-bot/menu.ts";
 
 Deno.test("buildMainMenu highlights active section", () => {
   const dash = buildMainMenu("dashboard");
-  assertEquals(dash.inline_keyboard[0][0].text, "✅ Dashboard");
-  assertEquals(dash.inline_keyboard[0][1].text, "Plans");
+  assertEquals(dash.inline_keyboard[0][0].text, "✅ 📊 Dashboard");
+  assertEquals(dash.inline_keyboard[0][1].text, "💳 Plans");
 
   const plans = buildMainMenu("plans");
-  assertEquals(plans.inline_keyboard[0][0].text, "Dashboard");
-  assertEquals(plans.inline_keyboard[0][1].text, "✅ Plans");
+  assertEquals(plans.inline_keyboard[0][0].text, "📊 Dashboard");
+  assertEquals(plans.inline_keyboard[0][1].text, "✅ 💳 Plans");
 });


### PR DESCRIPTION
## Summary
- enhance telegram bot menu with clear emoji icons
- adjust unit test expectations for new menu labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ac2439d48322a595bdce30ed77fc