### PR TITLE
fix: normalize miniapp path for /functions/v1

### DIFF
--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -51,6 +51,9 @@ async function readFileFrom(rootDir: URL, relPath: string): Promise<Response | n
 
 export async function serveStatic(req: Request, opts: StaticOpts): Promise<Response> {
   const url = new URL(req.url);
+  // Normalize Supabase's default /functions/v1 prefix so the same handler
+  // works whether the function is invoked at /miniapp or /functions/v1/miniapp.
+  url.pathname = url.pathname.replace(/^\/functions\/v1/, "");
   const path = url.pathname.replace(/\/+$/, ""); // strip trailing slash for routing
   const sec = { ...DEFAULT_SECURITY, ...(opts.security || {}) };
 

--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -25,9 +25,18 @@ Deno.test({
       "should not serve fallback HTML",
     );
 
+    // Supabase's default host rewrites use /functions/v1/miniapp; ensure it also works
+    const resRootV1 = await fetch(`${base}/functions/v1/miniapp/`);
+    assertEquals(resRootV1.status, 200);
+    await resRootV1.arrayBuffer();
+
     const resVersion = await fetch(`${base}/miniapp/version`);
     assertEquals(resVersion.status, 200);
     await resVersion.arrayBuffer();
+
+    const resVersionV1 = await fetch(`${base}/functions/v1/miniapp/version`);
+    assertEquals(resVersionV1.status, 200);
+    await resVersionV1.arrayBuffer();
 
     const resHeadVersion = await fetch(`${base}/miniapp/version`, {
       method: "HEAD",
@@ -43,6 +52,12 @@ Deno.test({
     assertEquals(resHead.status, 200);
     assertEquals(resHead.headers.get("x-content-type-options"), "nosniff");
     await resHead.arrayBuffer();
+
+    const resHeadV1 = await fetch(`${base}/functions/v1/miniapp/`, {
+      method: "HEAD",
+    });
+    assertEquals(resHeadV1.status, 200);
+    await resHeadV1.arrayBuffer();
 
     const resFooMissing = await fetch(`${base}/assets/foo.css`);
     assertEquals(resFooMissing.status, 404);


### PR DESCRIPTION
## Summary
- normalize static handler to remove `/functions/v1` prefix
- test miniapp edge host for `/functions/v1` routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f7a2a3548322bc2f246817dd618f