### PR TITLE
fix: correct miniapp navigation callback

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -298,7 +298,7 @@ export async function sendMiniAppOrBotOptions(chatId: number): Promise<void> {
     callback_data?: string;
     web_app?: { url: string };
   }[][] = [
-    [{ text: continueText, callback_data: "menu:plans" }],
+    [{ text: continueText, callback_data: "nav:plans" }],
   ];
   let text: string;
   if (url) {

--- a/tests/miniapp-options.test.ts
+++ b/tests/miniapp-options.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+const supaState: any = { tables: {} };
+(globalThis as any).__SUPA_MOCK__ = supaState;
+
+function setEnv() {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("TELEGRAM_WEBHOOK_SECRET", "testsecret");
+  Deno.env.set("SUPABASE_URL", "http://local");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
+}
+
+function cleanup() {
+  Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  Deno.env.delete("TELEGRAM_WEBHOOK_SECRET");
+  Deno.env.delete("SUPABASE_URL");
+  Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+  Deno.env.delete("SUPABASE_ANON_KEY");
+  supaState.tables = {};
+}
+
+Deno.test("sendMiniAppOrBotOptions uses nav:plans callback", async () => {
+  setEnv();
+  supaState.tables = {
+    kv_config: [{ key: "features:published", value: { data: { mini_app_enabled: false } } }],
+  };
+  const calls: Array<{ body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    await mod.sendMiniAppOrBotOptions(1);
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.reply_markup.inline_keyboard[0][0].callback_data, "nav:plans");
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- fix mini app option to use `nav:plans` callback so button works
- add test covering sendMiniAppOrBotOptions callback data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87fc4ffdc8322aada13e2c6724145