### PR TITLE
Fix miniapp storage retrieval and disable compression

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -74,16 +74,10 @@ function saveCache(key: string, resp: Response, body: Uint8Array, ttl: number) {
 // compression helper for html/json
 function maybeCompress(
   body: Uint8Array,
-  req: Request,
-  type: string,
+  _req: Request,
+  _type: string,
 ): { stream: ReadableStream | Uint8Array; encoding?: string } {
-  const ae = req.headers.get("accept-encoding") ?? "";
-  const enc = ae.includes("br") ? "br" : ae.includes("gzip") ? "gzip" : null;
-  if (!enc) return { stream: body };
-  if (!/^(text\/html|application\/json)/.test(type)) return { stream: body };
-  const cs = new CompressionStream(enc);
-  const stream = new Blob([body]).stream().pipeThrough(cs);
-  return { stream, encoding: enc };
+  return { stream: body };
 }
 
 async function fetchFromStorage(key: string): Promise<Uint8Array | null> {

--- a/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2.js
+++ b/supabase/functions/telegram-bot/vendor/esm.sh/@supabase/supabase-js@2.js
@@ -109,6 +109,16 @@ export function createClient(..._args) {
             data: { signedUrl: "https://example/signed" },
             error: null,
           }),
+          download: async (key) => {
+            try {
+              const data = await Deno.readFile(
+                `supabase/functions/miniapp/static/${key}`,
+              );
+              return { data: new Blob([data]), error: null };
+            } catch {
+              return { data: null, error: { message: "not found" } };
+            }
+          },
         };
       },
     },


### PR DESCRIPTION
## Summary
- add local download helper in Supabase mock storage
- simplify miniapp handler to skip compression to avoid invalid encodings

## Testing
- `SUPABASE_URL=http://local SUPABASE_SERVICE_ROLE_KEY=svc deno test tests --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check`

------
https://chatgpt.com/codex/tasks/task_e_68a88e8f348c83229624460bd032a3c5