### PR TITLE
feat: add LRU cache for miniapp

### DIFF
--- a/supabase/functions/miniapp/README.md
+++ b/supabase/functions/miniapp/README.md
@@ -76,4 +76,5 @@ The edge function needs the following secrets:
 - `MINIAPP_INDEX_KEY`
 - `MINIAPP_ASSETS_PREFIX`
 - `SERVE_FROM_STORAGE=true`
+- `MINIAPP_CACHE_LIMIT` (optional, defaults to 100)
 


### PR DESCRIPTION
## Summary
- add configurable LRU cache for miniapp edge function
- store compressed index responses in cache
- document optional MINIAPP_CACHE_LIMIT setting

## Testing
- `npm test` *(fails: expected text/css but got text/css; charset=UTF-8)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc3e93b8832290fca550d679e38e