### PR TITLE
fix: correct miniapp index markup

### DIFF
--- a/supabase/functions/miniapp/index.html
+++ b/supabase/functions/miniapp/index.html
@@ -1,9 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mini App</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,viewport-fit=cover"
+    />
+    <title>Dynamic Capital VIP • Mini App</title>
+    <!-- Telegram WebApp SDK -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- ensure mini app HTML uses proper doctype and metadata
- set viewport to include viewport-fit and use proper UTF-8 charset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3df64e4c8322bf73ad91197ebfe0