### PR TITLE
refactor: limit miniapp index error logging

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -231,9 +231,11 @@ export async function handler(req: Request): Promise<Response> {
         const indexContent = await Deno.readFile(staticIndexPath);
         arr = indexContent;
       } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         console.warn(
-          "[miniapp] React build not found in static/, falling back to storage",
-          error,
+          "[miniapp] React build not found in static/, falling back to storage:",
+          errorMessage,
         );
       }
     }


### PR DESCRIPTION
## Summary
- log only the error message when static index fails for miniapp

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae49dd26c48322883d6532e40478a3