### PR TITLE
refactor: load telegram menu labels from bot content

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -136,9 +136,9 @@ async function envOrSetting<T = string>(
   return await getSetting<T>(settingKey);
 }
 
-async function getContent<T = string>(
+export let getContent = async <T = string>(
   key: string,
-): Promise<T | null> {
+): Promise<T | null> => {
   const cached = getCached<T>(`c:${key}`);
   if (cached !== null) return cached;
   const client = getClient();
@@ -156,12 +156,11 @@ async function getContent<T = string>(
     console.error("Error getting content:", e);
   }
   return null;
+};
+
+// Test helper to override getContent
+export function __setGetContent(fn: typeof getContent) {
+  getContent = fn;
 }
 
-export {
-  getConfig,
-  setConfig,
-  requireSetting,
-  envOrSetting,
-  getContent,
-};
+export { envOrSetting, getConfig, getContent, requireSetting, setConfig };

--- a/supabase/functions/telegram-bot/admin-handlers/bot-content.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/bot-content.ts
@@ -1,4 +1,4 @@
-import { supabaseAdmin, sendMessage } from "./common.ts";
+import { sendMessage, supabaseAdmin } from "./common.ts";
 
 export async function handleContentManagement(
   chatId: number,
@@ -20,85 +20,41 @@ export async function handleContentManagement(
     }
 
     let contentMessage = `📱 *Bot Content Management*\\n\\n`;
-    contentMessage += `📝 *Editable Content (${content?.length || 0} items):*\\n\\n`;
+    contentMessage += `📝 *Editable Content (${
+      content?.length || 0
+    } items):*\\n\\n`;
 
-    const contentTypes: Record<string, string> = {
-      "welcome_message": "🚀 Welcome Message",
-      "about_us": "🏢 About Us",
-      "support_message": "🛟 Support Info",
-      "terms_conditions": "📋 Terms & Conditions",
-      "faq_general": "❓ FAQ Content",
-      "maintenance_message": "🔧 Maintenance Notice",
-      "vip_benefits": "💎 VIP Benefits",
-      "payment_instructions": "💳 Payment Instructions",
-      "help_message": "❓ Help Content",
-    };
+    const lines: string[] = [];
+    const buttons: { text: string; callback_data: string }[][] = [];
 
-    content?.forEach(
-      (
-        item: {
-          content_key: keyof typeof contentTypes;
-          is_active: boolean;
-          content_value: string;
-          updated_at: string;
-        },
-        index: number,
-      ) => {
-        const displayName = contentTypes[item.content_key] ||
-          `📄 ${item.content_key}`;
-        const status = item.is_active ? "🟢" : "🔴";
-        const preview = item.content_value.substring(0, 50) + "...";
-
-        contentMessage += `${index + 1}. ${status} ${displayName}\\n`;
-        contentMessage += `   📄 Preview: ${preview}\\n`;
-        contentMessage += `   🕐 Updated: ${
+    (content || []).forEach((item, index) => {
+      const status = item.is_active ? "🟢" : "🔴";
+      const preview = item.content_value.substring(0, 50) + "...";
+      lines.push(
+        `${
+          index + 1
+        }. ${status} ${item.content_key}\\n   📄 Preview: ${preview}\\n   🕐 Updated: ${
           new Date(item.updated_at).toLocaleDateString()
-        }\\n\\n`;
-      },
-    );
+        }\\n`,
+      );
+      buttons.push([{
+        text: item.content_key,
+        callback_data: `edit_content_${item.content_key}`,
+      }]);
+    });
 
-    const contentKeyboard = {
-      inline_keyboard: [
-        [
-          {
-            text: "🚀 Welcome Msg",
-            callback_data: "edit_content_welcome_message",
-          },
-          { text: "🏢 About Us", callback_data: "edit_content_about_us" },
-        ],
-        [
-          { text: "🛟 Support", callback_data: "edit_content_support_message" },
-          { text: "📋 Terms", callback_data: "edit_content_terms_conditions" },
-        ],
-        [
-          { text: "❓ FAQ", callback_data: "edit_content_faq_general" },
-          {
-            text: "🔧 Maintenance",
-            callback_data: "edit_content_maintenance_message",
-          },
-        ],
-        [
-          {
-            text: "💎 VIP Benefits",
-            callback_data: "edit_content_vip_benefits",
-          },
-          {
-            text: "💳 Payment Info",
-            callback_data: "edit_content_payment_instructions",
-          },
-        ],
-        [
-          { text: "➕ Add Content", callback_data: "add_new_content" },
-          { text: "👀 Preview All", callback_data: "preview_all_content" },
-        ],
-        [
-          { text: "🔄 Refresh", callback_data: "manage_table_bot_content" },
-          { text: "🔙 Back", callback_data: "table_management" },
-        ],
-      ],
-    };
+    contentMessage += lines.join("\\n");
 
-    await sendMessage(chatId, contentMessage, contentKeyboard);
+    buttons.push([
+      { text: "➕ Add Content", callback_data: "add_new_content" },
+      { text: "👀 Preview All", callback_data: "preview_all_content" },
+    ]);
+    buttons.push([
+      { text: "🔄 Refresh", callback_data: "manage_table_bot_content" },
+      { text: "🔙 Back", callback_data: "table_management" },
+    ]);
+
+    await sendMessage(chatId, contentMessage, { inline_keyboard: buttons });
   } catch (error) {
     console.error("Error in content management:", error);
     await sendMessage(
@@ -180,4 +136,3 @@ export async function handlePreviewAllContent(
     await sendMessage(chatId, "❌ Error fetching content preview.");
   }
 }
-

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -245,8 +245,7 @@ export async function sendMiniAppLink(
   if (!BOT_TOKEN) return null;
   if (!(await getFlag("mini_app_enabled", true))) {
     if (!silent) {
-      const msg =
-        await getContent("checkout_unavailable") ??
+      const msg = await getContent("checkout_unavailable") ??
         "<b>Checkout is currently unavailable.</b>\nPlease try again later.";
       await sendMessage(chatId, msg);
     }
@@ -381,13 +380,15 @@ async function handlePromoCommand(chatId: number): Promise<void> {
     return;
   }
   let text = "🎁 *Active Promotions*\n\nSelect a promo code:";
-  const inline_keyboard = promos.map((p: Record<string, unknown>, idx: number) => {
-    const value = p.discount_type === "percentage"
-      ? `${p.discount_value}%`
-      : `$${p.discount_value}`;
-    text += `\n${idx + 1}. ${p.code} - ${value}`;
-    return [{ text: String(p.code), callback_data: `promo:${p.code}` }];
-  });
+  const inline_keyboard = promos.map(
+    (p: Record<string, unknown>, idx: number) => {
+      const value = p.discount_type === "percentage"
+        ? `${p.discount_value}%`
+        : `$${p.discount_value}`;
+      text += `\n${idx + 1}. ${p.code} - ${value}`;
+      return [{ text: String(p.code), callback_data: `promo:${p.code}` }];
+    },
+  );
   await notifyUser(chatId, text, {
     parse_mode: "Markdown",
     reply_markup: { inline_keyboard },
@@ -576,39 +577,48 @@ function getDynamicCallbackHandler(
   }
   if (data.startsWith("edit_plan_duration_")) {
     const id = data.slice("edit_plan_duration_".length);
-    return (chatId, userId) => handlers.handleEditPlanDuration(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleEditPlanDuration(chatId, userId, id);
   }
   if (data.startsWith("edit_plan_features_")) {
     const id = data.slice("edit_plan_features_".length);
-    return (chatId, userId) => handlers.handleEditPlanFeatures(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleEditPlanFeatures(chatId, userId, id);
   }
   if (data.startsWith("toggle_plan_lifetime_")) {
     const id = data.slice("toggle_plan_lifetime_".length);
-    return (chatId, userId) => handlers.handleTogglePlanLifetime(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleTogglePlanLifetime(chatId, userId, id);
   }
   if (data.startsWith("add_plan_feature_")) {
     const id = data.slice("add_plan_feature_".length);
-    return (chatId, userId) => handlers.handleAddPlanFeature(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleAddPlanFeature(chatId, userId, id);
   }
   if (data.startsWith("remove_plan_feature_")) {
     const id = data.slice("remove_plan_feature_".length);
-    return (chatId, userId) => handlers.handleRemovePlanFeature(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleRemovePlanFeature(chatId, userId, id);
   }
   if (data.startsWith("replace_plan_features_")) {
     const id = data.slice("replace_plan_features_".length);
-    return (chatId, userId) => handlers.handleReplacePlanFeatures(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleReplacePlanFeatures(chatId, userId, id);
   }
   if (data.startsWith("confirm_delete_plan_")) {
     const id = data.slice("confirm_delete_plan_".length);
-    return (chatId, userId) => handlers.handleConfirmDeletePlan(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleConfirmDeletePlan(chatId, userId, id);
   }
   if (data.startsWith("delete_plan_confirmed_")) {
     const id = data.slice("delete_plan_confirmed_".length);
-    return (chatId, userId) => handlers.handleExecuteDeletePlan(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleExecuteDeletePlan(chatId, userId, id);
   }
   if (data.startsWith("edit_plan_")) {
     const id = data.slice("edit_plan_".length);
-    return (chatId, userId) => handlers.handleEditSpecificPlan(chatId, userId, id);
+    return (chatId, userId) =>
+      handlers.handleEditSpecificPlan(chatId, userId, id);
   }
   return null;
 }
@@ -635,10 +645,10 @@ async function menuView(
     const msg = await getContent("support_message");
     return {
       text: msg ?? "Support information is unavailable.",
-      extra: { reply_markup: buildMainMenu(section) },
+      extra: { reply_markup: await buildMainMenu(section) },
     };
   }
-  const markup = buildMainMenu(section) as {
+  const markup = await buildMainMenu(section) as {
     inline_keyboard: {
       text: string;
       callback_data?: string;
@@ -1002,7 +1012,10 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         return;
       }
       const finalAmount = resp.final_amount as number;
-      const text = `Promo ${code} applied to ${plan.name}.\nOutstanding Amount: ${plan.currency} ${finalAmount.toFixed(2)}`;
+      const text =
+        `Promo ${code} applied to ${plan.name}.\nOutstanding Amount: ${plan.currency} ${
+          finalAmount.toFixed(2)
+        }`;
       if (cb.message) {
         await editMessage(chatId, cb.message!.message_id!, text, {
           parse_mode: "Markdown",
@@ -1146,7 +1159,9 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
           )
           .join("\n\n");
         const instructions = await getContent("payment_instructions");
-        const amountLine = `Outstanding Amount: ${currency} ${amount.toFixed(2)}\n\n`;
+        const amountLine = `Outstanding Amount: ${currency} ${
+          amount.toFixed(2)
+        }\n\n`;
         const message = `${
           instructions ? `${instructions}\n\n` : ""
         }${amountLine}${list}\n\nPay Code: <code>${payCode}</code>\nAdd this in transfer remarks.\nPlease send a photo of your bank transfer receipt.`;
@@ -1201,8 +1216,12 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         } else if (cb.message) {
           const instructions = await getContent("payment_instructions");
           const msg = instructions
-            ? `${instructions}\n\nAmount: ${currency} ${amount.toFixed(2)}\nSend the payment to ${address} and reply with the transaction details for manual approval.`
-            : `Amount: ${currency} ${amount.toFixed(2)}\nSend the payment to ${address} and reply with the transaction details for manual approval.`;
+            ? `${instructions}\n\nAmount: ${currency} ${
+              amount.toFixed(2)
+            }\nSend the payment to ${address} and reply with the transaction details for manual approval.`
+            : `Amount: ${currency} ${
+              amount.toFixed(2)
+            }\nSend the payment to ${address} and reply with the transaction details for manual approval.`;
           await editMessage(chatId, cb.message!.message_id!, msg, {
             reply_markup: {
               inline_keyboard: [[{ text: "Back", callback_data: "nav:plans" }]],

--- a/supabase/functions/telegram-bot/menu.ts
+++ b/supabase/functions/telegram-bot/menu.ts
@@ -1,34 +1,66 @@
 export type MenuSection = "dashboard" | "plans" | "support";
 
-export function buildMainMenu(section: MenuSection) {
+import { getContent } from "../_shared/config.ts";
+
+export async function buildMainMenu(section: MenuSection) {
+  const [
+    dashboard,
+    plans,
+    support,
+    packages,
+    promo,
+    account,
+    faq,
+    education,
+    ask,
+    shouldibuy,
+  ] = await Promise.all([
+    getContent("menu_dashboard_label"),
+    getContent("menu_plans_label"),
+    getContent("menu_support_label"),
+    getContent("menu_packages_label"),
+    getContent("menu_promo_label"),
+    getContent("menu_account_label"),
+    getContent("menu_faq_label"),
+    getContent("menu_education_label"),
+    getContent("menu_ask_label"),
+    getContent("menu_shouldibuy_label"),
+  ]);
   return {
     inline_keyboard: [
       [
         {
-          text: `${section === "dashboard" ? "✅ " : ""}📊 Dashboard`,
+          text: `${section === "dashboard" ? "✅ " : ""}${
+            dashboard ?? "📊 Dashboard"
+          }`,
           callback_data: "nav:dashboard",
         },
         {
-          text: `${section === "plans" ? "✅ " : ""}💳 Plans`,
+          text: `${section === "plans" ? "✅ " : ""}${plans ?? "💳 Plans"}`,
           callback_data: "nav:plans",
         },
         {
-          text: `${section === "support" ? "✅ " : ""}💬 Support`,
+          text: `${section === "support" ? "✅ " : ""}${
+            support ?? "💬 Support"
+          }`,
           callback_data: "nav:support",
         },
       ],
       [
-        { text: "📦 Packages", callback_data: "cmd:packages" },
-        { text: "🎁 Promo", callback_data: "cmd:promo" },
-        { text: "👤 Account", callback_data: "cmd:account" },
+        { text: packages ?? "📦 Packages", callback_data: "cmd:packages" },
+        { text: promo ?? "🎁 Promo", callback_data: "cmd:promo" },
+        { text: account ?? "👤 Account", callback_data: "cmd:account" },
       ],
       [
-        { text: "❓ FAQ", callback_data: "cmd:faq" },
-        { text: "📚 Education", callback_data: "cmd:education" },
+        { text: faq ?? "❓ FAQ", callback_data: "cmd:faq" },
+        { text: education ?? "📚 Education", callback_data: "cmd:education" },
       ],
       [
-        { text: "🤖 Ask", callback_data: "cmd:ask" },
-        { text: "💡 Should I Buy?", callback_data: "cmd:shouldibuy" },
+        { text: ask ?? "🤖 Ask", callback_data: "cmd:ask" },
+        {
+          text: shouldibuy ?? "💡 Should I Buy?",
+          callback_data: "cmd:shouldibuy",
+        },
       ],
     ],
   };

--- a/tests/main-menu.test.ts
+++ b/tests/main-menu.test.ts
@@ -1,12 +1,32 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
 import { buildMainMenu } from "../supabase/functions/telegram-bot/menu.ts";
+import * as cfg from "../supabase/functions/_shared/config.ts";
 
-Deno.test("buildMainMenu highlights active section", () => {
-  const dash = buildMainMenu("dashboard");
+Deno.test("buildMainMenu highlights active section", async () => {
+  const original = cfg.getContent;
+  cfg.__setGetContent(async (key: string) => {
+    const map: Record<string, string> = {
+      menu_dashboard_label: "📊 Dashboard",
+      menu_plans_label: "💳 Plans",
+      menu_support_label: "💬 Support",
+      menu_packages_label: "📦 Packages",
+      menu_promo_label: "🎁 Promo",
+      menu_account_label: "👤 Account",
+      menu_faq_label: "❓ FAQ",
+      menu_education_label: "📚 Education",
+      menu_ask_label: "🤖 Ask",
+      menu_shouldibuy_label: "💡 Should I Buy?",
+    };
+    return map[key] ?? null;
+  });
+
+  const dash = await buildMainMenu("dashboard");
   assertEquals(dash.inline_keyboard[0][0].text, "✅ 📊 Dashboard");
   assertEquals(dash.inline_keyboard[0][1].text, "💳 Plans");
 
-  const plans = buildMainMenu("plans");
+  const plans = await buildMainMenu("plans");
   assertEquals(plans.inline_keyboard[0][0].text, "📊 Dashboard");
   assertEquals(plans.inline_keyboard[0][1].text, "✅ 💳 Plans");
+
+  cfg.__setGetContent(original);
 });


### PR DESCRIPTION
## Summary
- fetch main menu labels from `bot_content` so admins can edit via Telegram
- expose `__setGetContent` and use async menu builder
- build content management keyboard dynamically

## Testing
- `npm test` *(fails: start command includes Mini App button when env present, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae856ae7248322ae31b119138886b5