### PR TITLE
refactor: build menu with grammy inline keyboard

### DIFF
--- a/supabase/functions/telegram-bot/menu.ts
+++ b/supabase/functions/telegram-bot/menu.ts
@@ -1,8 +1,12 @@
 export type MenuSection = "dashboard" | "plans" | "support";
 
+import { InlineKeyboard } from "https://deno.land/x/grammy@v1.19.1/mod.ts";
+import type { InlineKeyboardMarkup } from "https://deno.land/x/grammy@v1.19.1/types.ts";
 import { getContent } from "../_shared/config.ts";
 
-export async function buildMainMenu(section: MenuSection) {
+export async function buildMainMenu(
+  section: MenuSection,
+): Promise<InlineKeyboardMarkup> {
   const [
     dashboard,
     plans,
@@ -26,42 +30,30 @@ export async function buildMainMenu(section: MenuSection) {
     getContent("menu_ask_label"),
     getContent("menu_shouldibuy_label"),
   ]);
-  return {
-    inline_keyboard: [
-      [
-        {
-          text: `${section === "dashboard" ? "✅ " : ""}${
-            dashboard ?? "📊 Dashboard"
-          }`,
-          callback_data: "nav:dashboard",
-        },
-        {
-          text: `${section === "plans" ? "✅ " : ""}${plans ?? "💳 Plans"}`,
-          callback_data: "nav:plans",
-        },
-        {
-          text: `${section === "support" ? "✅ " : ""}${
-            support ?? "💬 Support"
-          }`,
-          callback_data: "nav:support",
-        },
-      ],
-      [
-        { text: packages ?? "📦 Packages", callback_data: "cmd:packages" },
-        { text: promo ?? "🎁 Promo", callback_data: "cmd:promo" },
-        { text: account ?? "👤 Account", callback_data: "cmd:account" },
-      ],
-      [
-        { text: faq ?? "❓ FAQ", callback_data: "cmd:faq" },
-        { text: education ?? "📚 Education", callback_data: "cmd:education" },
-      ],
-      [
-        { text: ask ?? "🤖 Ask", callback_data: "cmd:ask" },
-        {
-          text: shouldibuy ?? "💡 Should I Buy?",
-          callback_data: "cmd:shouldibuy",
-        },
-      ],
-    ],
-  };
+
+  const kb = new InlineKeyboard()
+    .text(
+      `${section === "dashboard" ? "✅ " : ""}${dashboard ?? "📊 Dashboard"}`,
+      "nav:dashboard",
+    )
+    .text(
+      `${section === "plans" ? "✅ " : ""}${plans ?? "💳 Plans"}`,
+      "nav:plans",
+    )
+    .text(
+      `${section === "support" ? "✅ " : ""}${support ?? "💬 Support"}`,
+      "nav:support",
+    )
+    .row()
+    .text(packages ?? "📦 Packages", "cmd:packages")
+    .text(promo ?? "🎁 Promo", "cmd:promo")
+    .text(account ?? "👤 Account", "cmd:account")
+    .row()
+    .text(faq ?? "❓ FAQ", "cmd:faq")
+    .text(education ?? "📚 Education", "cmd:education")
+    .row()
+    .text(ask ?? "🤖 Ask", "cmd:ask")
+    .text(shouldibuy ?? "💡 Should I Buy?", "cmd:shouldibuy");
+
+  return kb;
 }

--- a/tests/main-menu.test.ts
+++ b/tests/main-menu.test.ts
@@ -1,24 +1,33 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
-import { buildMainMenu } from "../supabase/functions/telegram-bot/menu.ts";
-import * as cfg from "../supabase/functions/_shared/config.ts";
+
+Deno.env.set("SUPABASE_URL", "http://localhost");
+Deno.env.set("SUPABASE_ANON_KEY", "anon");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service");
+
+const { buildMainMenu } = await import(
+  "../supabase/functions/telegram-bot/menu.ts"
+);
+const cfg = await import("../supabase/functions/_shared/config.ts");
 
 Deno.test("buildMainMenu highlights active section", async () => {
   const original = cfg.getContent;
-  cfg.__setGetContent(async (key: string) => {
-    const map: Record<string, string> = {
-      menu_dashboard_label: "📊 Dashboard",
-      menu_plans_label: "💳 Plans",
-      menu_support_label: "💬 Support",
-      menu_packages_label: "📦 Packages",
-      menu_promo_label: "🎁 Promo",
-      menu_account_label: "👤 Account",
-      menu_faq_label: "❓ FAQ",
-      menu_education_label: "📚 Education",
-      menu_ask_label: "🤖 Ask",
-      menu_shouldibuy_label: "💡 Should I Buy?",
-    };
-    return map[key] ?? null;
-  });
+  cfg.__setGetContent(
+    async <T>(key: string): Promise<T | null> => {
+      const map: Record<string, string | undefined> = {
+        menu_dashboard_label: "📊 Dashboard",
+        menu_plans_label: "💳 Plans",
+        menu_support_label: "💬 Support",
+        menu_packages_label: "📦 Packages",
+        menu_promo_label: "🎁 Promo",
+        menu_account_label: "👤 Account",
+        menu_faq_label: "❓ FAQ",
+        menu_education_label: "📚 Education",
+        menu_ask_label: "🤖 Ask",
+        menu_shouldibuy_label: "💡 Should I Buy?",
+      };
+      return (map[key] ?? null) as T | null;
+    },
+  );
 
   const dash = await buildMainMenu("dashboard");
   assertEquals(dash.inline_keyboard[0][0].text, "✅ 📊 Dashboard");


### PR DESCRIPTION
## Summary
- return `InlineKeyboard` instance from `buildMainMenu`
- make main menu test self-contained and generic

## Testing
- `deno test -A --unsafely-ignore-certificate-errors tests/main-menu.test.ts`
- `deno check --allow-import --unsafely-ignore-certificate-errors supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts` *(fails: TS2345 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae91487f948322a95d1da93241f248