### PR TITLE
fix: set proper content type when uploading miniapp HTML

### DIFF
--- a/supabase/functions/build-miniapp/index.ts
+++ b/supabase/functions/build-miniapp/index.ts
@@ -81,9 +81,14 @@ export async function handler(req: Request): Promise<Response> {
     // Upload the HTML to storage
     const { error: uploadError } = await supabase.storage
       .from('miniapp')
-      .upload('index.html', new Blob([comingSoonHTML], { type: 'text/html' }), {
-        upsert: true
-      });
+      .upload(
+        'index.html',
+        new Blob([comingSoonHTML], { type: 'text/html; charset=utf-8' }),
+        {
+          upsert: true,
+          contentType: 'text/html; charset=utf-8',
+        },
+      );
 
     if (uploadError) {
       throw uploadError;


### PR DESCRIPTION
## Summary
- ensure miniapp build page uploads with `text/html` content type so browsers render correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64a26e1ac8322bedbd13af5c5b5a1