### PR TITLE
feat: load Supabase config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ TELEGRAM_WEBHOOK_SECRET=
 MINI_APP_URL=
 
 ## Additional Supabase credentials
+# Public anon key for client-side calls
 SUPABASE_ANON_KEY=
 SUPABASE_PROJECT_ID=
 SUPABASE_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ PII; rate limits enabled.
 Full list and usage notes: [docs/env.md](docs/env.md).
 
 - SUPABASE_URL
+- SUPABASE_ANON_KEY
 - SUPABASE_SERVICE_ROLE_KEY
 - VITE_SUPABASE_URL
 - VITE_SUPABASE_KEY

--- a/docs/env.md
+++ b/docs/env.md
@@ -6,16 +6,16 @@ example value, and where it's referenced in the repository.
 
 ## Supabase
 
-| Key                         | Purpose                                                   | Required | Example                   | Used in                                                                               |
-| --------------------------- | --------------------------------------------------------- | -------- | ------------------------- | ------------------------------------------------------------------------------------- |
-| `SUPABASE_URL`              | Base URL of the Supabase project.                         | Yes      | `https://xyz.supabase.co` | `src/utils/config.ts`, `supabase/functions/telegram-bot/index.ts`                     |
-| `SUPABASE_ANON_KEY`         | Public anon key for client-side calls.                    | Yes      | `eyJ...`                  | `supabase/functions/theme-get/index.ts`, `supabase/functions/miniapp/src/lib/edge.ts` |
-| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for privileged Supabase access.          | Yes      | `service-role-key`        | `src/utils/config.ts`, `supabase/functions/telegram-bot/index.ts`                     |
-| `SUPABASE_PROJECT_ID`       | Supabase project reference used to build URLs in scripts. | No       | `abcd1234`                | `scripts/ping-webhook.ts`, `scripts/miniapp-health-check.ts`                          |
-| `SUPABASE_ACCESS_TOKEN`     | Token for Supabase CLI operations.                        | No       | `sbp_at...`               | Supabase CLI only                                                                     |
-| `SUPABASE_DB_PASSWORD`      | Postgres password for local or CI usage.                  | No       | `super-secret`            | Supabase CLI only                                                                     |
-| `VITE_SUPABASE_URL`         | Base URL for the frontend Supabase client.                | Yes      | `https://xyz.supabase.co` | `src/integrations/supabase/client.ts`                                                 |
-| `VITE_SUPABASE_KEY`         | Public anon key for the frontend client.                  | Yes      | `eyJ...`                  | `src/integrations/supabase/client.ts`                                                 |
+| Key                         | Purpose                                                   | Required | Example                     | Used in                                                                                                   |
+| --------------------------- | --------------------------------------------------------- | -------- | --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `SUPABASE_URL`              | Base URL of the Supabase project.                         | Yes      | `https://xyz.supabase.co`   | `src/utils/config.ts`, `src/integrations/supabase/client.ts`, `supabase/functions/telegram-bot/index.ts` |
+| `SUPABASE_ANON_KEY`         | Public anon key for client-side calls.                    | Yes      | `eyJ...`                    | `src/integrations/supabase/client.ts`, `supabase/functions/theme-get/index.ts`, `supabase/functions/miniapp/src/lib/edge.ts` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key for privileged Supabase access.          | Yes      | `service-role-key`          | `src/utils/config.ts`, `supabase/functions/telegram-bot/index.ts`                                         |
+| `SUPABASE_PROJECT_ID`       | Supabase project reference used to build URLs in scripts. | No       | `abcd1234`                  | `scripts/ping-webhook.ts`, `scripts/miniapp-health-check.ts`                                              |
+| `SUPABASE_ACCESS_TOKEN`     | Token for Supabase CLI operations.                        | No       | `sbp_at...`                 | Supabase CLI only                                                                                         |
+| `SUPABASE_DB_PASSWORD`      | Postgres password for local or CI usage.                  | No       | `super-secret`              | Supabase CLI only                                                                                         |
+| `VITE_SUPABASE_URL`         | Base URL for the frontend Supabase client.                | Yes      | `https://xyz.supabase.co`   | `src/integrations/supabase/client.ts`                                                                     |
+| `VITE_SUPABASE_KEY`         | Public anon key for the frontend client.                  | Yes      | `eyJ...`                    | `src/integrations/supabase/client.ts`                                                                     |
 
 ## Telegram
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,18 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
-const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+const SUPABASE_URL =
+  (typeof Deno !== "undefined"
+    ? Deno.env.get("SUPABASE_URL")
+    : typeof process !== "undefined"
+    ? process.env.SUPABASE_URL
+    : import.meta.env?.VITE_SUPABASE_URL) || "";
+const SUPABASE_KEY =
+  (typeof Deno !== "undefined"
+    ? Deno.env.get("SUPABASE_ANON_KEY")
+    : typeof process !== "undefined"
+    ? process.env.SUPABASE_ANON_KEY
+    : import.meta.env?.VITE_SUPABASE_KEY) || "";
 
 if (!SUPABASE_URL || !SUPABASE_KEY) {
   throw new Error(


### PR DESCRIPTION
## Summary
- read Supabase URL and anon key from environment instead of hard-coded values
- document required Supabase variables in README and env docs
- note anon key in `.env.example`

## Testing
- `SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=anon VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_KEY=anon npm test` *(fails: checkout-init rejects unauthenticated requests; start command omits Mini App button when env missing; miniapp edge host routes)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeeec663083228c2d045963f3bc82