### PR TITLE
feat(accessibility): label footer contact buttons

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -124,6 +124,7 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
                     onClick={() => handleContactClick(contact.url)}
                     className="h-7 w-7 p-0 hover:bg-primary/10 hover:text-primary transition-colors"
                     title={`Follow us on ${contact.platform}`}
+                    aria-label={`Follow us on ${contact.platform}`}
                   >
                     {contact.icon_emoji ? (
                       <span className="text-xs">{contact.icon_emoji}</span>
@@ -216,6 +217,7 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
                       onClick={() => handleContactClick(contact.url)}
                       className="h-8 w-8 p-0 hover:bg-primary/10 hover:text-primary transition-colors"
                       title={`Follow us on ${contact.platform}`}
+                      aria-label={`Follow us on ${contact.platform}`}
                     >
                       {contact.icon_emoji ? (
                         <span className="text-sm">{contact.icon_emoji}</span>


### PR DESCRIPTION
## Summary
- add aria-labels to footer contact buttons for better screen reader support

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf2a56d348322a06639e85ab50911