### PR TITLE
feat: apply red brand palette

### DIFF
--- a/src/components/admin/AdminDataManager.tsx
+++ b/src/components/admin/AdminDataManager.tsx
@@ -226,7 +226,7 @@ export const AdminDataManager = () => {
       return (
         <div className="grid grid-cols-1 gap-4">
           <div>
-            <Label htmlFor="key">Key <span className="text-red-500">*</span></Label>
+            <Label htmlFor="key">Key <span className="text-dc-brand">*</span></Label>
             <Input
               id="key"
               value={kvConfigForm.key}
@@ -254,7 +254,7 @@ export const AdminDataManager = () => {
       return (
         <div className="grid grid-cols-1 gap-4">
           <div>
-            <Label htmlFor="telegram_id">Telegram ID <span className="text-red-500">*</span></Label>
+            <Label htmlFor="telegram_id">Telegram ID <span className="text-dc-brand">*</span></Label>
             <Input
               id="telegram_id"
               value={abuseBanForm.telegram_id}

--- a/src/components/admin/AdminLogs.tsx
+++ b/src/components/admin/AdminLogs.tsx
@@ -81,9 +81,9 @@ export function AdminLogs() {
   const getActionColor = (actionType: string) => {
     switch (actionType.toLowerCase()) {
       case 'approve': return 'bg-green-500/10 text-green-500 border-green-500/20';
-      case 'reject': return 'bg-red-500/10 text-red-500 border-red-500/20';
+      case 'reject': return 'bg-dc-brand/10 text-dc-brand border-dc-brand/20';
       case 'update': return 'bg-blue-500/10 text-blue-500 border-blue-500/20';
-      case 'delete': return 'bg-red-500/10 text-red-500 border-red-500/20';
+      case 'delete': return 'bg-dc-brand/10 text-dc-brand border-dc-brand/20';
       case 'create': return 'bg-green-500/10 text-green-500 border-green-500/20';
       default: return 'bg-muted text-muted-foreground';
     }

--- a/src/components/admin/BotDiagnostics.tsx
+++ b/src/components/admin/BotDiagnostics.tsx
@@ -151,7 +151,7 @@ export function BotDiagnostics() {
       case 'error':
       case 'failed':
       case 'offline':
-        return 'bg-red-500/10 text-red-500 border-red-500/20';
+        return 'bg-dc-brand/10 text-dc-brand border-dc-brand/20';
       case 'warning':
       case 'pending':
         return 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20';

--- a/src/components/admin/BroadcastManager.tsx
+++ b/src/components/admin/BroadcastManager.tsx
@@ -141,7 +141,7 @@ export function BroadcastManager() {
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed': return 'bg-green-500/10 text-green-500 border-green-500/20';
-      case 'failed': return 'bg-red-500/10 text-red-500 border-red-500/20';
+      case 'failed': return 'bg-dc-brand/10 text-dc-brand border-dc-brand/20';
       case 'sending': return 'bg-blue-500/10 text-blue-500 border-blue-500/20';
       case 'scheduled': return 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20';
       default: return 'bg-muted text-muted-foreground';
@@ -279,7 +279,7 @@ export function BroadcastManager() {
                           </span>
                         )}
                         {message.failed_deliveries !== undefined && message.failed_deliveries > 0 && (
-                          <span className="text-red-600">
+                          <span className="text-dc-brand-dark">
                             ✗ {message.failed_deliveries}
                           </span>
                         )}

--- a/src/components/admin/SystemStatus.tsx
+++ b/src/components/admin/SystemStatus.tsx
@@ -208,7 +208,7 @@ export const SystemStatus = () => {
       case "healthy":
         return <CheckCircle className="h-4 w-4 text-green-500" />;
       case "error":
-        return <XCircle className="h-4 w-4 text-red-500" />;
+        return <XCircle className="h-4 w-4 text-dc-brand" />;
       case "warning":
         return <AlertTriangle className="h-4 w-4 text-yellow-500" />;
       default:
@@ -324,7 +324,7 @@ export const SystemStatus = () => {
                   tables.every((t) => t.status === "healthy")
                 ? <span className="text-green-500">Excellent</span>
                 : errorFunctions > 0
-                ? <span className="text-red-500">Issues</span>
+                ? <span className="text-dc-brand">Issues</span>
                 : <span className="text-yellow-500">Warning</span>}
             </div>
             <p className="text-xs text-muted-foreground">
@@ -380,7 +380,7 @@ export const SystemStatus = () => {
                               : "No response time"}
                           </p>
                           {func.error && (
-                            <p className="text-xs text-red-500">{func.error}</p>
+                            <p className="text-xs text-dc-brand">{func.error}</p>
                           )}
                         </div>
                       </div>
@@ -564,7 +564,7 @@ export const SystemStatus = () => {
                     </div>
                   )
                   : (
-                    <div className="flex items-center gap-2 text-red-600">
+                    <div className="flex items-center gap-2 text-dc-brand-dark">
                       <XCircle className="h-4 w-4" />
                       <span>Some edge functions need attention</span>
                     </div>
@@ -578,7 +578,7 @@ export const SystemStatus = () => {
                     </div>
                   )
                   : (
-                    <div className="flex items-center gap-2 text-red-600">
+                    <div className="flex items-center gap-2 text-dc-brand-dark">
                       <XCircle className="h-4 w-4" />
                       <span>Some database tables have issues</span>
                     </div>

--- a/src/components/checkout/WebCheckout.tsx
+++ b/src/components/checkout/WebCheckout.tsx
@@ -451,7 +451,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
                   "text-xs p-2 rounded",
                   promoValidation.valid 
                     ? "bg-green-500/10 text-green-600 border border-green-500/20" 
-                    : "bg-red-500/10 text-red-600 border border-red-500/20"
+                    : "bg-dc-brand/10 text-dc-brand-dark border border-dc-brand/20"
                 )}>
                   {promoValidation.valid 
                     ? `${promoValidation.discount_type === 'percentage' ? promoValidation.discount_value + '%' : '$' + promoValidation.discount_value} discount applied!`

--- a/src/components/miniapp/MobilePaymentFlow.tsx
+++ b/src/components/miniapp/MobilePaymentFlow.tsx
@@ -278,7 +278,7 @@ export const MobilePaymentFlow: React.FC<MobilePaymentFlowProps> = ({
                       whileTap={{ scale: method.available ? 0.98 : 1 }}
                     >
                       {method.recommended && (
-                        <Badge className="absolute -top-2 right-2 bg-gradient-to-r from-orange-500 to-red-500 text-white text-xs">
+                        <Badge className="absolute -top-2 right-2 bg-gradient-to-r from-orange-500 to-dc-brand text-white text-xs">
                           Popular
                         </Badge>
                       )}

--- a/src/components/miniapp/PlanSection.tsx
+++ b/src/components/miniapp/PlanSection.tsx
@@ -246,7 +246,7 @@ export default function PlanSection() {
                        "flex-1 min-h-[44px] px-4 py-2 ui-rounded-lg border transition-all duration-200",
                        "placeholder:text-muted-foreground font-medium",
                        promoValidation?.valid === true && "border-green-500 ring-2 ring-green-500/20",
-                       promoValidation?.valid === false && "border-red-500 ring-2 ring-red-500/20",
+                      promoValidation?.valid === false && "border-dc-brand ring-2 ring-dc-brand/20",
                        !promoValidation && "border-border hover:border-border/80 focus:border-primary focus:ring-2 focus:ring-primary/20"
                      )}
                    />
@@ -260,7 +260,7 @@ export default function PlanSection() {
                    </Button>
                  </div>
                 {promoValidation && (
-                  <div className={`text-xs p-2 rounded transition-all duration-300 ${promoValidation.valid ? 'bg-green-500/10 text-green-600' : 'bg-red-500/10 text-red-600'}`}>
+                  <div className={`text-xs p-2 rounded transition-all duration-300 ${promoValidation.valid ? 'bg-green-500/10 text-green-600' : 'bg-dc-brand/10 text-dc-brand-dark'}`}>
                     {promoValidation.valid 
                       ? `${promoValidation.discount_type === 'percentage' ? promoValidation.discount_value + '%' : '$' + promoValidation.discount_value} discount applied!`
                       : promoValidation.reason
@@ -322,7 +322,7 @@ export default function PlanSection() {
                                 exit={{ scale: 0, rotate: 180 }}
                                 transition={{ type: "spring", stiffness: 260, damping: 20 }}
                               >
-                                <Badge className="bg-gradient-to-r from-orange-500 to-red-500 text-white text-xs animate-pulse ui-p-xs">
+                                <Badge className="bg-gradient-to-r from-orange-500 to-dc-brand text-white text-xs animate-pulse ui-p-xs">
                                   <motion.div
                                     animate={{ rotate: [0, 15, -15, 0] }}
                                     transition={{ duration: 2, repeat: Infinity }}

--- a/src/components/miniapp/StatusSection.tsx
+++ b/src/components/miniapp/StatusSection.tsx
@@ -85,7 +85,7 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
     }
     
     if (subscription.is_expired) {
-      return <Badge variant="destructive" className="bg-red-500/10 text-red-600 border-red-500/30">Expired</Badge>;
+      return <Badge variant="destructive" className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30">Expired</Badge>;
     }
     
     if (subscription.is_vip) {
@@ -223,7 +223,7 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
                           ? 'bg-green-500/10 text-green-600 border-green-500/30'
                           : subscription.payment_status === 'pending'
                           ? 'bg-yellow-500/10 text-yellow-600 border-yellow-500/30'
-                          : 'bg-red-500/10 text-red-600 border-red-500/30'
+                          : 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30'
                       }
                     >
                       {subscription.payment_status}

--- a/src/components/miniapp/VIPSubscriptionPlans.tsx
+++ b/src/components/miniapp/VIPSubscriptionPlans.tsx
@@ -89,10 +89,10 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
   };
 
   const getPlanColor = (index: number, popular: boolean) => {
-    if (popular) return 'from-red-500 to-red-600';
+    if (popular) return 'from-dc-brand to-dc-brand-dark';
     switch (index) {
       case 0: return 'from-blue-500 to-blue-600';
-      case 1: return 'from-red-500 to-red-600';
+      case 1: return 'from-dc-brand to-dc-brand-dark';
       case 2: return 'from-purple-500 to-purple-600';
       default: return 'from-gray-500 to-gray-600';
     }
@@ -132,7 +132,7 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
           >
             <Card className="h-full border-0">
               {plan.popular && (
-                <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-red-500 to-red-600 text-white text-center py-1 text-xs font-medium">
+                <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-1 text-xs font-medium">
                   MOST POPULAR
                 </div>
               )}
@@ -142,7 +142,7 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
                 </div>
                 <CardTitle className="text-lg">{plan.name}</CardTitle>
                 <div className="space-y-1">
-                  <div className="text-2xl font-bold text-red-500">${plan.price}</div>
+                  <div className="text-2xl font-bold text-dc-brand">${plan.price}</div>
                   <div className="text-sm text-muted-foreground">
                     {plan.is_lifetime ? 'One-time payment' : `${plan.duration_months} month${plan.duration_months > 1 ? 's' : ''}`}
                   </div>
@@ -153,7 +153,7 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
                   onClick={() => handleSelectPlan(plan.id)}
                   className={cn(
                     "w-full",
-                    plan.popular && "bg-red-500 hover:bg-red-600"
+                    plan.popular && "bg-dc-brand hover:bg-dc-brand-dark"
                   )}
                 >
                   Choose Plan
@@ -173,7 +173,7 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
         <div className="text-center space-y-2">
           <div className="flex items-center justify-center gap-2 mb-4">
             <ThreeDEmoticon emoji="👑" size={32} intensity={0.4} animate={true} />
-            <h2 className="text-2xl font-bold bg-gradient-to-r from-red-500 to-red-600 bg-clip-text text-transparent">
+            <h2 className="text-2xl font-bold bg-gradient-to-r from-dc-brand to-dc-brand-dark bg-clip-text text-transparent">
               VIP Subscription Plans
             </h2>
             <ThreeDEmoticon emoji="✨" size={28} intensity={0.3} animate={true} />
@@ -201,11 +201,11 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
                 >
                   <Card className={cn(
                     "h-full border-2 transition-all duration-300",
-                    plan.popular ? "border-red-500 shadow-lg shadow-red-500/20" : "border-border hover:border-red-300"
+                    plan.popular ? "border-dc-brand shadow-lg shadow-dc-brand/20" : "border-border hover:border-dc-brand-light"
                   )}>
                     {/* Popular Badge */}
                     {plan.popular && (
-                      <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-red-500 to-red-600 text-white text-center py-2 font-medium">
+                      <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-2 font-medium">
                         <div className="flex items-center justify-center gap-1">
                           <Crown className="h-4 w-4" />
                           MOST POPULAR
@@ -241,7 +241,7 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
                       
                       {/* Pricing */}
                       <div className="space-y-1">
-                        <div className="text-3xl font-bold text-red-500">
+                        <div className="text-3xl font-bold text-dc-brand">
                           ${plan.price}
                           <span className="text-base text-muted-foreground ml-1">
                             {plan.currency}
@@ -279,8 +279,8 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
                         className={cn(
                           "w-full font-semibold transition-all duration-300 group-hover:shadow-lg",
                           plan.popular 
-                            ? "bg-red-500 hover:bg-red-600 shadow-red-500/20" 
-                            : "hover:bg-red-500 hover:text-white"
+                            ? "bg-dc-brand hover:bg-dc-brand-dark shadow-dc-brand/20"
+                            : "hover:bg-dc-brand hover:text-white"
                         )}
                         size="lg"
                       >
@@ -306,12 +306,12 @@ export function VIPSubscriptionPlans({ onSelectPlan, compact = false }: VIPSubsc
         </div>
 
         {/* Features Summary */}
-        <div className="mt-8 p-6 bg-gradient-to-r from-red-500/10 to-red-600/10 rounded-lg border border-red-500/20">
+        <div className="mt-8 p-6 bg-gradient-to-r from-dc-brand/10 to-dc-brand-dark/10 rounded-lg border border-dc-brand/20">
           <div className="text-center space-y-4">
             <div className="flex items-center justify-center gap-2">
-              <Shield className="h-6 w-6 text-red-500" />
+              <Shield className="h-6 w-6 text-dc-brand" />
               <h3 className="text-lg font-semibold">All Plans Include</h3>
-              <Shield className="h-6 w-6 text-red-500" />
+              <Shield className="h-6 w-6 text-dc-brand" />
             </div>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
               <div className="flex items-center gap-2">

--- a/src/components/receipts/PaymentStatus.tsx
+++ b/src/components/receipts/PaymentStatus.tsx
@@ -95,7 +95,7 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
       case 'pending':
         return <Clock className="h-5 w-5 text-yellow-500" />;
       case 'failed':
-        return <XCircle className="h-5 w-5 text-red-500" />;
+        return <XCircle className="h-5 w-5 text-dc-brand" />;
       default:
         return <Clock className="h-5 w-5 text-gray-500" />;
     }
@@ -108,7 +108,7 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
       case 'pending':
         return <Badge className="bg-yellow-500/10 text-yellow-600 border-yellow-500/20">Pending Review</Badge>;
       case 'failed':
-        return <Badge className="bg-red-500/10 text-red-600 border-red-500/20">Failed</Badge>;
+        return <Badge className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/20">Failed</Badge>;
       default:
         return <Badge variant="outline">Unknown</Badge>;
     }
@@ -206,9 +206,9 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
           )}
 
           {payment.status === 'failed' && (
-            <Alert className="border-red-500/20 bg-red-500/10">
-              <XCircle className="h-4 w-4 text-red-600" />
-              <AlertDescription className="text-red-600">
+            <Alert className="border-dc-brand/20 bg-dc-brand/10">
+              <XCircle className="h-4 w-4 text-dc-brand-dark" />
+              <AlertDescription className="text-dc-brand-dark">
                 <strong>Payment Failed</strong> Please try again or contact support for assistance.
               </AlertDescription>
             </Alert>

--- a/src/components/receipts/ReceiptUploader.tsx
+++ b/src/components/receipts/ReceiptUploader.tsx
@@ -119,9 +119,9 @@ export const ReceiptUploader: React.FC<ReceiptUploaderProps> = ({
         )}
 
         {uploadStatus === 'error' && (
-          <Alert className="border-red-500/20 bg-red-500/10">
-            <AlertCircle className="h-4 w-4 text-red-600" />
-            <AlertDescription className="text-red-600">
+          <Alert className="border-dc-brand/20 bg-dc-brand/10">
+            <AlertCircle className="h-4 w-4 text-dc-brand-dark" />
+            <AlertDescription className="text-dc-brand-dark">
               Upload failed. Please try again or contact support.
             </AlertDescription>
           </Alert>

--- a/src/components/shared/ServiceStack.tsx
+++ b/src/components/shared/ServiceStack.tsx
@@ -67,7 +67,7 @@ export function ServiceStack({ services, className }: ServiceStackProps) {
           title: 'Personal Mentor', 
           description: 'One-on-one guidance from experienced professional traders',
           color: 'text-orange-500',
-          gradient: 'from-orange-500 to-red-600'
+          gradient: 'from-orange-500 to-dc-brand-dark'
         };
         if (text.includes('VIP')) return { 
           icon: Sparkles, 

--- a/src/components/telegram/BotDashboard.tsx
+++ b/src/components/telegram/BotDashboard.tsx
@@ -318,8 +318,8 @@ const BotDashboard = () => {
 
         <Card className="p-8 bg-gradient-to-br from-background to-muted border-0 shadow-lg hover:shadow-xl transition-all cursor-pointer group">
           <div className="text-center space-y-4">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-red-500/10 rounded-2xl group-hover:bg-red-500/20 transition-colors">
-              <Bell className="w-8 h-8 text-red-500" />
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-dc-brand/10 rounded-2xl group-hover:bg-dc-brand/20 transition-colors">
+              <Bell className="w-8 h-8 text-dc-brand" />
             </div>
             <div>
               <h3 className="text-xl font-semibold mb-2">Notifications</h3>
@@ -650,8 +650,8 @@ const BotDashboard = () => {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
           <div className="text-center space-y-4">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-red-500/10 rounded-lg">
-              <MessageSquare className="w-6 h-6 text-red-500" />
+            <div className="inline-flex items-center justify-center w-12 h-12 bg-dc-brand/10 rounded-lg">
+              <MessageSquare className="w-6 h-6 text-dc-brand" />
             </div>
             <div>
               <p className="text-2xl font-bold">12</p>
@@ -727,7 +727,7 @@ const BotDashboard = () => {
                 <Badge
                   variant="outline"
                   className={ticket.status === "Open"
-                    ? "border-red-500 text-red-600"
+                    ? "border-dc-brand text-dc-brand-dark"
                     : ticket.status === "Pending"
                     ? "border-yellow-500 text-yellow-600"
                     : "border-green-500 text-green-600"}
@@ -863,7 +863,7 @@ const BotDashboard = () => {
                           ? "border-green-500 text-green-600"
                           : promo.status === "Disabled"
                           ? "border-orange-500 text-orange-600"
-                          : "border-red-500 text-red-600"
+                          : "border-dc-brand text-dc-brand-dark"
                       }
                     >
                       {promo.status}
@@ -889,7 +889,7 @@ const BotDashboard = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="text-red-600 hover:text-red-700"
+                  className="text-dc-brand-dark hover:text-dc-brand-dark"
                 >
                   Delete
                 </Button>

--- a/src/components/telegram/FeatureCard.tsx
+++ b/src/components/telegram/FeatureCard.tsx
@@ -28,7 +28,7 @@ export const FeatureCard = ({
       case "orange":
         return "text-orange-500";
       case "red":
-        return "text-red-500";
+        return "text-dc-brand";
       case "teal":
         return "text-teal-500";
       default:
@@ -45,7 +45,7 @@ export const FeatureCard = ({
       case "orange":
         return "bg-orange-500/10 group-hover:bg-orange-500/20";
       case "red":
-        return "bg-red-500/10 group-hover:bg-red-500/20";
+        return "bg-dc-brand/10 group-hover:bg-dc-brand/20";
       case "teal":
         return "bg-teal-500/10 group-hover:bg-teal-500/20";
       default:

--- a/src/components/telegram/StatusCard.tsx
+++ b/src/components/telegram/StatusCard.tsx
@@ -29,7 +29,7 @@ export const StatusCard = ({
       case "warning":
         return "text-orange-500";
       case "error":
-        return "text-red-500";
+        return "text-dc-brand";
       case "loading":
         return "text-muted-foreground";
       default:

--- a/src/components/ui/enhanced-button.tsx
+++ b/src/components/ui/enhanced-button.tsx
@@ -38,7 +38,7 @@ const enhancedButtonVariants = cva(
           "before:animate-shimmer"
         ],
         attention: [
-          "bg-gradient-to-r from-orange-500 via-red-500 to-orange-500 text-white font-bold",
+          "bg-gradient-to-r from-orange-500 via-dc-brand to-orange-500 text-white font-bold",
           "shadow-lg shadow-orange-500/30 hover:shadow-xl hover:shadow-orange-500/50",
           "animate-attention hover:animate-none hover:scale-110",
           "border-2 border-orange-400/50 hover:border-orange-300",

--- a/src/components/ui/enhanced-promo-input.tsx
+++ b/src/components/ui/enhanced-promo-input.tsx
@@ -78,7 +78,7 @@ export function EnhancedPromoInput({
               variant="ghost"
               size="sm"
               onClick={onRemove}
-              className="h-6 w-6 p-0 hover:bg-red-100 dark:hover:bg-red-950/20"
+              className="h-6 w-6 p-0 hover:bg-dc-brand-light dark:hover:bg-dc-brand-dark/20"
             >
               <X className="h-3 w-3" />
             </Button>
@@ -111,7 +111,7 @@ export function EnhancedPromoInput({
                 "placeholder:text-muted-foreground font-medium",
                 state === "focus" && "border-primary ring-2 ring-primary/20",
                 state === "success" && "border-green-500 ring-2 ring-green-500/20",
-                state === "error" && "border-red-500 ring-2 ring-red-500/20",
+                state === "error" && "border-dc-brand ring-2 ring-dc-brand/20",
                 state === "default" && "border-border hover:border-border/80"
               )}
             />
@@ -150,7 +150,7 @@ export function EnhancedPromoInput({
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
-            className="text-body-sm text-red-600 dark:text-red-400"
+            className="text-body-sm text-dc-brand-dark dark:text-dc-brand-light"
           >
             {errorMessage}
           </motion.p>

--- a/src/components/ui/error-handling.tsx
+++ b/src/components/ui/error-handling.tsx
@@ -75,10 +75,10 @@ export function NetworkStatus({ className }: NetworkStatusProps) {
   }
 
   return (
-    <Alert className={`border-red-500/20 bg-red-500/10 ${className}`}>
+    <Alert className={`border-dc-brand/20 bg-dc-brand/10 ${className}`}>
       <WifiOff className="h-4 w-4" />
       <AlertDescription className="flex items-center justify-between">
-        <span className="text-red-600">
+        <span className="text-dc-brand-dark">
           Connection lost. Some features may not work properly.
         </span>
         <Button
@@ -121,9 +121,9 @@ export class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return this.props.fallback || (
-        <Alert className="border-red-500/20 bg-red-500/10">
+        <Alert className="border-dc-brand/20 bg-dc-brand/10">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription className="text-red-600">
+          <AlertDescription className="text-dc-brand-dark">
             Something went wrong. Please refresh the page.
           </AlertDescription>
         </Alert>
@@ -168,10 +168,10 @@ export function RetryableComponent({ children, onRetry, error, loading }: Retrya
 
   if (error) {
     return (
-      <Alert className="border-red-500/20 bg-red-500/10">
+      <Alert className="border-dc-brand/20 bg-dc-brand/10">
         <AlertCircle className="h-4 w-4" />
         <AlertDescription className="flex items-center justify-between">
-          <span className="text-red-600">{error}</span>
+          <span className="text-dc-brand-dark">{error}</span>
           <Button
             variant="outline"
             size="sm"

--- a/src/components/ui/stateful-button.tsx
+++ b/src/components/ui/stateful-button.tsx
@@ -91,7 +91,7 @@ export function StatefulButton({
             initial={{ opacity: 0, scale: 0.8, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.8, y: -10 }}
-            className="flex items-center gap-2 text-red-600 dark:text-red-400"
+            className="flex items-center gap-2 text-dc-brand-dark dark:text-dc-brand-light"
           >
             <X className="h-4 w-4" />
             {errorText}
@@ -129,7 +129,7 @@ export function StatefulButton({
         "min-w-[120px] transition-all duration-300",
         currentState === "loading" && "cursor-wait",
         currentState === "success" && "bg-green-600 hover:bg-green-700 border-green-600",
-        currentState === "error" && "bg-red-600 hover:bg-red-700 border-red-600",
+        currentState === "error" && "bg-dc-brand-dark hover:bg-dc-brand-dark border-dc-brand-dark",
         className
       )}
       disabled={disabled || currentState !== "idle"}

--- a/src/components/ui/system-health.tsx
+++ b/src/components/ui/system-health.tsx
@@ -89,7 +89,7 @@ export function SystemHealth({ className, showDetails = false }: SystemHealthPro
     switch (status) {
       case 'healthy': return <CheckCircle className="h-4 w-4 text-green-500" />;
       case 'degraded': return <AlertCircle className="h-4 w-4 text-yellow-500" />;
-      case 'error': return <AlertCircle className="h-4 w-4 text-red-500" />;
+      case 'error': return <AlertCircle className="h-4 w-4 text-dc-brand" />;
       default: return <Clock className="h-4 w-4 text-gray-500" />;
     }
   };
@@ -101,7 +101,7 @@ export function SystemHealth({ className, showDetails = false }: SystemHealthPro
       case 'degraded': 
         return <Badge className="bg-yellow-500/10 text-yellow-600 border-yellow-500/30">Degraded</Badge>;
       case 'error': 
-        return <Badge className="bg-red-500/10 text-red-600 border-red-500/30">Error</Badge>;
+        return <Badge className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30">Error</Badge>;
       default: 
         return <Badge variant="outline">Unknown</Badge>;
     }
@@ -166,7 +166,7 @@ export function SystemHealth({ className, showDetails = false }: SystemHealthPro
             </div>
             <div className="space-y-1">
               <p className="text-xs text-muted-foreground">Failed</p>
-              <p className="text-sm font-medium text-red-500">
+              <p className="text-sm font-medium text-dc-brand">
                 {healthStatus.performance.failed_checks}
               </p>
             </div>
@@ -190,7 +190,7 @@ export function SystemHealth({ className, showDetails = false }: SystemHealthPro
                   {check.status === 'ok' ? (
                     <CheckCircle className="h-4 w-4 text-green-500" />
                   ) : (
-                    <AlertCircle className="h-4 w-4 text-red-500" />
+                    <AlertCircle className="h-4 w-4 text-dc-brand" />
                   )}
                 </div>
               </div>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-dc-brand-light group-[.destructive]:hover:text-dc-brand-light group-[.destructive]:focus:ring-dc-brand-light group-[.destructive]:focus:ring-offset-dc-brand-dark",
       className,
     )}
     toast-close=""

--- a/src/components/welcome/WelcomeMessage.tsx
+++ b/src/components/welcome/WelcomeMessage.tsx
@@ -274,8 +274,8 @@ export const WelcomeMessage = () => {
 
           <Card className="border-2 hover:border-primary/50 transition-colors">
             <CardHeader>
-              <div className="w-12 h-12 rounded-lg bg-red-500/10 flex items-center justify-center mb-4">
-                <Clock className="w-6 h-6 text-red-500" />
+              <div className="w-12 h-12 rounded-lg bg-dc-brand/10 flex items-center justify-center mb-4">
+                <Clock className="w-6 h-6 text-dc-brand" />
               </div>
               <CardTitle>Real-time Alerts</CardTitle>
               <CardDescription>

--- a/src/index.css
+++ b/src/index.css
@@ -14,16 +14,16 @@
   --card-foreground: 224 71.4% 4.1%;
   --popover: 0 0% 100%;
   --popover-foreground: 224 71.4% 4.1%;
-  --primary: 0 84% 60%;
+  --primary: 0 72% 51%;
   --primary-foreground: 0 0% 98%;
   --secondary: 0 68% 95%;
   --secondary-foreground: 0 45% 20%;
   --muted: 0 5% 96%;
   --muted-foreground: 0 5% 45%;
-  --elevated: 0 84% 5%;
-  --accent: 0 72% 51%;
+  --elevated: 0 72% 10%;
+  --accent: 0 85% 65%;
   --accent-foreground: 0 0% 98%;
-  --destructive: 0 84% 60%;
+  --destructive: 0 72% 51%;
   --destructive-foreground: 0 0% 98%;
   --border: 0 10% 89%;
   --input: 0 10% 89%;
@@ -48,7 +48,7 @@
   --dc-brand-light: 0 85% 65%;
   --dc-brand-dark: 0 65% 40%;
   --dc-secondary: 0 85% 65%;
-  --dc-accent: 14 90% 60%;
+  --dc-accent: 0 90% 60%;
 
   /* Motion-Enhanced Red Gradients */
   --gradient-motion-primary: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--dc-brand-light)) 50%, hsl(var(--dc-accent)) 100%);
@@ -58,9 +58,9 @@
                         linear-gradient(to bottom, hsl(var(--background)), hsl(var(--background)));
 
   /* Glass Motion Effects */
-  --glass-motion-bg: rgba(220, 38, 38, 0.12);
-  --glass-motion-border: rgba(239, 68, 68, 0.25);
-  --glass-motion-shadow: 0 12px 40px rgba(185, 28, 28, 0.4);
+  --glass-motion-bg: hsl(var(--dc-brand) / 0.12);
+  --glass-motion-border: hsl(var(--dc-brand-light) / 0.25);
+  --glass-motion-shadow: 0 12px 40px hsl(var(--dc-brand-dark) / 0.4);
   --glass-motion-blur: blur(24px) saturate(1.8) brightness(1.1);
 
   /* Interactive Motion Shadows */
@@ -84,7 +84,7 @@
   --card-foreground: 0 5% 98%;
   --popover: 0 8% 8%;
   --popover-foreground: 0 5% 98%;
-  --primary: 0 84% 60%;
+  --primary: 0 72% 51%;
   --primary-foreground: 0 5% 10%;
   --secondary: 0 10% 15%;
   --secondary-foreground: 0 5% 98%;
@@ -100,9 +100,9 @@
   --ring: 0 85% 65%;
 
   /* Dark mode motion effects */
-  --glass-motion-bg: rgba(220, 38, 38, 0.15);
-  --glass-motion-border: rgba(239, 68, 68, 0.2);
-  --glass-motion-shadow: 0 12px 40px rgba(185, 28, 28, 0.6);
+  --glass-motion-bg: hsl(var(--dc-brand) / 0.15);
+  --glass-motion-border: hsl(var(--dc-brand-light) / 0.2);
+  --glass-motion-shadow: 0 12px 40px hsl(var(--dc-brand-dark) / 0.6);
   --gradient-motion-bg: radial-gradient(ellipse at top, hsl(var(--primary)/0.2) 0%, transparent 60%), 
                         radial-gradient(ellipse at bottom, hsl(var(--dc-brand-light)/0.15) 0%, transparent 60%),
                         linear-gradient(to bottom, hsl(var(--background)), hsl(var(--background)));

--- a/src/pages/BotStatus.tsx
+++ b/src/pages/BotStatus.tsx
@@ -187,7 +187,7 @@ export default function BotStatusPage() {
                       </p>
                     )
                     : (
-                      <div className="text-red-600 space-y-1">
+                      <div className="text-destructive space-y-1">
                         <p>❌ Bot has configuration issues:</p>
                         {!botStatus.bot_status?.includes("✅") && (
                           <p>• Bot API connection failed</p>

--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -153,7 +153,7 @@ const Education: React.FC = () => {
       case "Intermediate":
         return "bg-yellow-100 text-yellow-800";
       case "Advanced":
-        return "bg-red-100 text-red-800";
+        return "bg-dc-brand/10 text-dc-brand-dark";
       default:
         return "bg-gray-100 text-gray-800";
     }

--- a/src/pages/MiniApp.tsx
+++ b/src/pages/MiniApp.tsx
@@ -128,8 +128,8 @@ export default function MiniApp() {
                           value={tab.id}
                           className={cn(
                             "flex-1 h-12 flex-col gap-1 text-xs font-medium rounded-lg mx-1",
-                            "data-[state=active]:bg-red-500 data-[state=active]:text-white data-[state=active]:shadow-lg",
-                            "hover:bg-red-500/10 hover:text-red-500 transition-all duration-200"
+                            "data-[state=active]:bg-dc-brand data-[state=active]:text-white data-[state=active]:shadow-lg",
+                            "hover:bg-dc-brand/10 hover:text-dc-brand transition-all duration-200"
                           )}
                         >
                           <tab.icon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- switch global tokens to new red brand hues and update gradients
- use semantic `dc-brand` colors across components and pages
- map interactive elements to `dc-brand` token variants

## Testing
- `npm test` *(fails: checkout-init rejects unauthenticated requests; start command omits Mini App button when env missing; miniapp edge host routes)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfc2f6c448322a49144153f07564e