### PR TITLE
feat: use semantic status tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -697,6 +697,16 @@
   --error: 0 84% 60%;
   --error-foreground: 0 86% 97%;
 
+  /* Status semantic aliases */
+  --status-success: var(--success);
+  --status-success-foreground: var(--success-foreground);
+  --status-warning: var(--warning);
+  --status-warning-foreground: var(--warning-foreground);
+  --status-info: var(--info);
+  --status-info-foreground: var(--info-foreground);
+  --status-error: var(--error);
+  --status-error-foreground: var(--error-foreground);
+
   /* Typography scale */
   --text-title: 2rem;
   --text-heading: 1.5rem;
@@ -925,19 +935,19 @@
 
   /* === STATUS INDICATORS === */
   .status-success {
-    @apply bg-green-100 text-green-800 border border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800;
+    @apply bg-success text-success border border-success;
   }
 
   .status-warning {
-    @apply bg-yellow-100 text-yellow-800 border border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800;
+    @apply bg-warning text-warning border border-warning;
   }
 
   .status-error {
-    @apply bg-red-100 text-red-800 border border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800;
+    @apply bg-error text-error border border-error;
   }
 
   .status-info {
-    @apply bg-blue-100 text-blue-800 border border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800;
+    @apply bg-info text-info border border-info;
   }
 
   /* === UNIVERSAL SPACING === */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -76,16 +76,20 @@ export default {
           foreground: "hsl(var(--destructive-foreground))",
         },
         success: {
-          DEFAULT: "hsl(var(--success))",
-          foreground: "hsl(var(--success-foreground))",
+          DEFAULT: "hsl(var(--status-success))",
+          foreground: "hsl(var(--status-success-foreground))",
         },
         warning: {
-          DEFAULT: "hsl(var(--warning))",
-          foreground: "hsl(var(--warning-foreground))",
+          DEFAULT: "hsl(var(--status-warning))",
+          foreground: "hsl(var(--status-warning-foreground))",
         },
         info: {
-          DEFAULT: "hsl(var(--info))",
-          foreground: "hsl(var(--info-foreground))",
+          DEFAULT: "hsl(var(--status-info))",
+          foreground: "hsl(var(--status-info-foreground))",
+        },
+        error: {
+          DEFAULT: "hsl(var(--status-error))",
+          foreground: "hsl(var(--status-error-foreground))",
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",


### PR DESCRIPTION
## Summary
- add semantic status aliases for success, warning, info and error
- refactor status indicator utilities to use Tailwind status colors
- expose new status colors in tailwind config

## Testing
- `npm test` *(fails: checkout-init rejects unauthenticated requests)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bdfee64e20832295b31b90802ea50f