### PR TITLE
refactor: centralize edge function calls

### DIFF
--- a/src/components/miniapp/HomeLanding.tsx
+++ b/src/components/miniapp/HomeLanding.tsx
@@ -26,6 +26,7 @@ import { AnimatedStatusDisplay } from "./AnimatedStatusDisplay";
 import { ThreeDEmoticon, TradingEmoticonSet } from "@/components/ui/three-d-emoticons";
 import { motion, AnimatePresence } from "framer-motion";
 import { parentVariants, childVariants, slowParentVariants } from "@/lib/motion-variants";
+import { callEdgeFunction } from "@/config/supabase";
 
 interface BotContent {
   content_key: string;
@@ -65,12 +66,11 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
     const fetchContent = async () => {
       try {
         // Fetch about us and services from bot_content
-        const contentResponse = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/content-batch', {
+        const contentResponse = await callEdgeFunction('CONTENT_BATCH', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
+          body: {
             keys: ['about_us', 'our_services', 'announcements']
-          })
+          }
         });
         
         if (contentResponse.ok) {
@@ -104,12 +104,11 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
 
         // Fetch subscription status if in Telegram
         if (isInTelegram && telegramData?.user?.id) {
-          const subResponse = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/subscription-status', {
+          const subResponse = await callEdgeFunction('SUBSCRIPTION_STATUS', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
+            body: {
               telegram_id: telegramData.user.id
-            })
+            }
           });
           if (subResponse.ok) {
             const subData = await subResponse.json();
@@ -150,9 +149,18 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
 
   const bgOpacity = Math.min(scrollY / 300, 0.8);
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <ThreeDEmoticon emoji="⌛" size={32} />
+        <span className="ml-2 text-muted-foreground">Loading content...</span>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6 relative z-10">
-      <motion.div 
+      <motion.div
         className="space-y-4 scroll-bg-transition"
         variants={slowParentVariants}
         initial="hidden"

--- a/src/components/miniapp/PlanSection.tsx
+++ b/src/components/miniapp/PlanSection.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { motion, AnimatePresence } from "framer-motion";
 import { parentVariants, childVariants, fastParentVariants } from "@/lib/motion-variants";
 import { cn } from "@/lib/utils";
+import { callEdgeFunction } from "@/config/supabase";
 
 interface Plan {
   id: string;
@@ -121,16 +122,15 @@ export default function PlanSection() {
         return;
       }
 
-      const response = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/promo-validate', {
+      const response = await callEdgeFunction('PROMO_VALIDATE', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+        body: {
           code: promoCode,
           telegram_id: telegramUserId || 'web-user',
           plan_id: selectedPlanId
-        })
+        }
       });
-      
+
       if (!response.ok) {
         throw new Error('Network error');
       }


### PR DESCRIPTION
## Summary
- streamline home content and subscription fetches through `callEdgeFunction`
- add loading indicator for mini app home
- route promo code validation via `callEdgeFunction`

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be0e66e438832298f670d1deb5d7be