### PR TITLE
feat: display edge function status in UI

### DIFF
--- a/src/components/admin/SystemStatus.tsx
+++ b/src/components/admin/SystemStatus.tsx
@@ -74,6 +74,7 @@ export const SystemStatus = () => {
     "setup-webhook",
     "cleanup-old-sessions",
     "cleanup-old-receipts",
+    "web-app-health",
   ];
 
   const coreTables = [

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { SocialLinks } from "@/components/ui/social-icons";
+import { EdgeFunctionStatus } from "@/components/shared/EdgeFunctionStatus";
 
 interface ContactLink {
   id: string;
@@ -114,10 +115,10 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
         <div className="container mx-auto px-4 py-3">
           <div className="flex flex-col items-center gap-2">
             {/* Social Media Icons Row */}
-            {contacts.length > 0 && (
-              <div className="flex gap-2">
-                {contacts.slice(0, 4).map((contact) => (
-                  <Button
+          {contacts.length > 0 && (
+            <div className="flex gap-2">
+              {contacts.slice(0, 4).map((contact) => (
+                <Button
                     key={contact.id}
                     variant="ghost"
                     size="sm"
@@ -135,10 +136,11 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
                 ))}
               </div>
             )}
-            
+
             <p className="text-xs text-muted-foreground text-center">
               © {new Date().getFullYear()} Dynamic Capital. All rights reserved.
             </p>
+            <EdgeFunctionStatus />
           </div>
         </div>
       </footer>
@@ -246,8 +248,11 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
           <p className="text-xs text-muted-foreground text-center sm:text-left">
             © {new Date().getFullYear()} Dynamic Capital. All rights reserved.
           </p>
-          <div className="hidden sm:block">
-            <ThemeToggle />
+          <div className="flex items-center gap-4">
+            <EdgeFunctionStatus />
+            <div className="hidden sm:block">
+              <ThemeToggle />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/shared/EdgeFunctionStatus.tsx
+++ b/src/components/shared/EdgeFunctionStatus.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Badge } from "@/components/ui/badge";
+
+interface HealthResponse {
+  overall_status?: "healthy" | "degraded" | "error";
+}
+
+export const EdgeFunctionStatus = () => {
+  const [status, setStatus] = useState<
+    "checking" | "healthy" | "degraded" | "error"
+  >("checking");
+
+  useEffect(() => {
+    const checkStatus = async () => {
+      try {
+        const { data, error } = await supabase.functions.invoke<HealthResponse>(
+          "web-app-health",
+          { method: "GET" },
+        );
+        if (error) {
+          setStatus("error");
+          return;
+        }
+        setStatus(data?.overall_status || "degraded");
+      } catch (_err) {
+        setStatus("error");
+      }
+    };
+
+    checkStatus();
+  }, []);
+
+  const variant =
+    status === "healthy"
+      ? "default"
+      : status === "degraded"
+      ? "secondary"
+      : status === "checking"
+      ? "outline"
+      : "destructive";
+
+  const label =
+    status === "checking"
+      ? "Checking edge functions..."
+      : `Edge functions: ${status}`;
+
+  return <Badge variant={variant}>{label}</Badge>;
+};
+
+export default EdgeFunctionStatus;


### PR DESCRIPTION
## Summary
- show edge function health in footer
- monitor web-app-health in admin system status

## Testing
- `npm test` *(fails: checkout-init rejects unauthenticated requests; start command omits Mini App button when env missing; miniapp edge host routes)*
- `npm run lint` *(fails: Unexpected any in web-app-analytics, web-app-health)*

------
https://chatgpt.com/codex/tasks/task_e_68be131afe8083228630cf30bc3ae959