### PR TITLE
feat: add VIP gate and dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@eslint/js": "^9.9.0",
+        "@eslint/js": "^9.35.0",
         "@tailwindcss/typography": "^0.5.15",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4749,6 +4749,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.34.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
+      "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^9.35.0",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import TelegramSetup from "./pages/TelegramSetup";
 import MiniApp from "./pages/MiniApp";
 import Plans from "./pages/Plans";
 import Contact from "./pages/Contact";
+import VipDashboard from "./pages/VipDashboard";
 
 const queryClient = new QueryClient();
 
@@ -167,6 +168,11 @@ const AppContent = () => {
               <Route path="/miniapp" element={
                 <RouteTransition variant="blur">
                   <PageWrapper background={false}><MiniApp /></PageWrapper>
+                </RouteTransition>
+              } />
+              <Route path="/vip-dashboard" element={
+                <RouteTransition variant="fade">
+                  <PageWrapper><VipDashboard /></PageWrapper>
                 </RouteTransition>
               } />
               <Route path="/welcome" element={

--- a/src/components/auth/VipGate.tsx
+++ b/src/components/auth/VipGate.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { useTelegramAuth } from "@/hooks/useTelegramAuth";
+
+interface VipGateProps {
+  children: React.ReactNode;
+  redirectTo?: string;
+}
+
+export function VipGate({ children, redirectTo = "/plans" }: VipGateProps) {
+  const { isVip, loading } = useTelegramAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!loading && !isVip) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [loading, isVip, navigate, redirectTo]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <span className="ml-2">Checking VIP status...</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!isVip) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
+export default VipGate;

--- a/src/pages/VipDashboard.tsx
+++ b/src/pages/VipDashboard.tsx
@@ -1,0 +1,25 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import VipGate from "@/components/auth/VipGate";
+
+const VipDashboardContent = () => (
+  <div className="container mx-auto p-6">
+    <Card>
+      <CardHeader>
+        <CardTitle>VIP Dashboard</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground">
+          Exclusive insights and features for VIP members.
+        </p>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+export default function VipDashboard() {
+  return (
+    <VipGate>
+      <VipDashboardContent />
+    </VipGate>
+  );
+}


### PR DESCRIPTION
## Summary
- add VipGate component using useTelegramAuth to check VIP status
- add VipDashboard page and route protected by VipGate
- redirect non-VIP users to upgrade plans

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: deno not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be816f300c8322857ee5cf3ba31917