### PR TITLE
refactor routing with lazy loaded pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,38 +2,21 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Route, Routes, useNavigate, useLocation } from "react-router-dom";
-import { useEffect } from "react";
+import { BrowserRouter, Routes, useNavigate, useLocation } from "react-router-dom";
+import { useEffect, Suspense } from "react";
 import { AnimatePresence } from "framer-motion";
 import { AuthProvider } from "@/hooks/useAuth";
 import { TelegramAuthProvider } from "@/hooks/useTelegramAuth";
 import { AdminAuthProvider } from "@/hooks/useAdminAuth";
 import { useTheme } from "@/hooks/useTheme";
-import { MotionThemeProvider, MotionPage } from "@/components/ui/motion-theme";
-import { RouteTransition, PageWrapper } from "@/components/ui/route-transitions";
+import { MotionThemeProvider } from "@/components/ui/motion-theme";
 import { ScrollProgressBar } from "@/components/ui/scroll-progress";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
 import MobileBottomNav from "./components/navigation/MobileBottomNav";
 import SkipToContent from "./components/navigation/SkipToContent";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
-import Landing from "./pages/Landing";
-import Index from "./pages/Index";
-import Auth from "./pages/Auth";
-import Education from "./pages/Education";
-import BuildMiniApp from "./pages/BuildMiniApp";
-import NotFound from "./pages/NotFound";
-import AdminDashboard from "./pages/AdminDashboard";
-import { WelcomeMessage } from "./components/welcome/WelcomeMessage";
-import BotStatus from "./pages/BotStatus";
-import Checkout from "./pages/Checkout";
-import PaymentStatus from "./pages/PaymentStatus";
-import MiniAppDemo from "./pages/MiniAppDemo";
-import TelegramSetup from "./pages/TelegramSetup";
-import MiniApp from "./pages/MiniApp";
-import Plans from "./pages/Plans";
-import Contact from "./pages/Contact";
-import VipDashboard from "./pages/VipDashboard";
+import appRoutes from "./routes";
 
 const queryClient = new QueryClient();
 
@@ -84,108 +67,9 @@ const AppContent = () => {
           tabIndex={-1}
         >
           <AnimatePresence mode="wait">
-            <Routes location={location} key={location.pathname}>
-              <Route path="/" element={
-                <RouteTransition variant="blur">
-                  <PageWrapper><Landing /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/dashboard" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><Index /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/auth" element={
-                <RouteTransition variant="slide">
-                  <PageWrapper><Auth /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/plans" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><Plans /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/contact" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><Contact /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/checkout" element={
-                <RouteTransition variant="slide">
-                  <PageWrapper><Checkout /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/payment-success" element={
-                <RouteTransition variant="scale">
-                  <PageWrapper><PaymentStatus /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/payment-canceled" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><PaymentStatus /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/payment-status" element={
-                <RouteTransition variant="slide">
-                  <PageWrapper><PaymentStatus /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/education" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><Education /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/admin" element={
-                <RouteTransition variant="blur">
-                  <PageWrapper><AdminDashboard /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/admin/system-health" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><AdminDashboard /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/bot-status" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><BotStatus /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/build-miniapp" element={
-                <RouteTransition variant="slide">
-                  <PageWrapper><BuildMiniApp /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/miniapp-demo" element={
-                <RouteTransition variant="blur">
-                  <PageWrapper background={false}><MiniAppDemo /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/telegram-setup" element={
-                <RouteTransition variant="slide">
-                  <PageWrapper><TelegramSetup /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/miniapp" element={
-                <RouteTransition variant="blur">
-                  <PageWrapper background={false}><MiniApp /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/vip-dashboard" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><VipDashboard /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="/welcome" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><WelcomeMessage /></PageWrapper>
-                </RouteTransition>
-              } />
-              <Route path="*" element={
-                <RouteTransition variant="fade">
-                  <PageWrapper><NotFound /></PageWrapper>
-                </RouteTransition>
-              } />
-            </Routes>
+            <Suspense fallback={<div className="p-4 text-center">Loading...</div>}>
+              <Routes location={location} key={location.pathname}>{appRoutes}</Routes>
+            </Suspense>
           </AnimatePresence>
         </main>
         

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,230 @@
+import { lazy } from "react";
+import { Route } from "react-router-dom";
+import { RouteTransition, PageWrapper } from "@/components/ui/route-transitions";
+
+const Landing = lazy(() => import("./pages/Landing"));
+const Index = lazy(() => import("./pages/Index"));
+const Auth = lazy(() => import("./pages/Auth"));
+const Education = lazy(() => import("./pages/Education"));
+const BuildMiniApp = lazy(() => import("./pages/BuildMiniApp"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const AdminDashboard = lazy(() => import("./pages/AdminDashboard"));
+const BotStatus = lazy(() => import("./pages/BotStatus"));
+const Checkout = lazy(() => import("./pages/Checkout"));
+const PaymentStatus = lazy(() => import("./pages/PaymentStatus"));
+const MiniAppDemo = lazy(() => import("./pages/MiniAppDemo"));
+const TelegramSetup = lazy(() => import("./pages/TelegramSetup"));
+const MiniApp = lazy(() => import("./pages/MiniApp"));
+const Plans = lazy(() => import("./pages/Plans"));
+const Contact = lazy(() => import("./pages/Contact"));
+const VipDashboard = lazy(() => import("./pages/VipDashboard"));
+const WelcomeMessage = lazy(() =>
+  import("./components/welcome/WelcomeMessage").then((m) => ({ default: m.WelcomeMessage }))
+);
+
+export const appRoutes = (
+  <>
+    <Route
+      path="/"
+      element={
+        <RouteTransition variant="blur">
+          <PageWrapper>
+            <Landing />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/dashboard"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <Index />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/auth"
+      element={
+        <RouteTransition variant="slide">
+          <PageWrapper>
+            <Auth />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/plans"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <Plans />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/contact"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <Contact />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/checkout"
+      element={
+        <RouteTransition variant="slide">
+          <PageWrapper>
+            <Checkout />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/payment-success"
+      element={
+        <RouteTransition variant="scale">
+          <PageWrapper>
+            <PaymentStatus />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/payment-canceled"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <PaymentStatus />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/payment-status"
+      element={
+        <RouteTransition variant="slide">
+          <PageWrapper>
+            <PaymentStatus />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/education"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <Education />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/admin"
+      element={
+        <RouteTransition variant="blur">
+          <PageWrapper>
+            <AdminDashboard />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/admin/system-health"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <AdminDashboard />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/bot-status"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <BotStatus />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/build-miniapp"
+      element={
+        <RouteTransition variant="slide">
+          <PageWrapper>
+            <BuildMiniApp />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/miniapp-demo"
+      element={
+        <RouteTransition variant="blur">
+          <PageWrapper background={false}>
+            <MiniAppDemo />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/telegram-setup"
+      element={
+        <RouteTransition variant="slide">
+          <PageWrapper>
+            <TelegramSetup />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/miniapp"
+      element={
+        <RouteTransition variant="blur">
+          <PageWrapper background={false}>
+            <MiniApp />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/vip-dashboard"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <VipDashboard />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="/welcome"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <WelcomeMessage />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+    <Route
+      path="*"
+      element={
+        <RouteTransition variant="fade">
+          <PageWrapper>
+            <NotFound />
+          </PageWrapper>
+        </RouteTransition>
+      }
+    />
+  </>
+);
+
+export default appRoutes;


### PR DESCRIPTION
## Summary
- lazy load all pages and centralize route definitions
- wrap router with Suspense for loading state

## Testing
- `npm run lint` (fails: Unexpected any in supabase functions)
- `npm test` (fails: checkout-init rejects unauthenticated requests, start command omits Mini App button when env missing, miniapp edge host routes)


------
https://chatgpt.com/codex/tasks/task_e_68be8542df848322bf2e7111de92d5a8