### PR TITLE
Use themeChanged event for Telegram webapp

### DIFF
--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -70,15 +70,22 @@ export function useTheme() {
     const tg = window.Telegram?.WebApp;
     
     if (tg) {
-      // For Telegram users, poll for theme changes
+      // For Telegram users, prefer the WebApp event API
       const handleTelegramTheme = () => {
         setSystemTheme(tg.colorScheme);
       };
-      
+
       // Initial check
       handleTelegramTheme();
-      
-      // Poll every second for theme changes
+
+      if (typeof tg.onEvent === 'function') {
+        tg.onEvent('themeChanged', handleTelegramTheme);
+        return () => {
+          tg.offEvent?.('themeChanged', handleTelegramTheme);
+        };
+      }
+
+      // Fallback to polling if onEvent is unavailable
       const interval = setInterval(handleTelegramTheme, 1000);
       return () => clearInterval(interval);
     } else {


### PR DESCRIPTION
## Summary
- Prefer Telegram WebApp `themeChanged` event for theme updates
- Preserve system matchMedia listener for non-Telegram users
- Fall back to polling when WebApp event API is unavailable

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & prefer-const errors in supabase functions)*

------
https://chatgpt.com/codex/tasks/task_e_68be894686c8832288ba16a3a08da64c