### PR TITLE
Fix miniapp build by adding PostCSS config

### DIFF
--- a/miniapp/postcss.config.js
+++ b/miniapp/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: {},
+};


### PR DESCRIPTION
## Summary
- add local PostCSS config so miniapp builds without Tailwind dependency

## Testing
- `npm run build:miniapp`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be8c66caf48322ba484e552b7d037d