### PR TITLE
Add VIP dashboard navigation and enhance plan details

### DIFF
--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -105,6 +105,7 @@ const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
                       texts={[
                         "#1 Premium Trading Platform",
                         "5000+ Active VIP Members",
+                        "Seamless VIP Dashboard",
                         "92% Success Rate Proven",
                         "24/7 Expert Support"
                       ]}

--- a/src/components/miniapp/AnimatedStatusDisplay.tsx
+++ b/src/components/miniapp/AnimatedStatusDisplay.tsx
@@ -274,7 +274,7 @@ export function AnimatedStatusDisplay({
                 whileTap={{ scale: 0.98 }}
                 onClick={() => {
                   const url = new URL(window.location.href);
-                  url.searchParams.set('tab', 'status');
+                  url.searchParams.set('tab', 'dashboard');
                   window.history.pushState({}, '', url.toString());
                   window.dispatchEvent(new PopStateEvent('popstate'));
                 }}

--- a/src/components/miniapp/PlanSection.tsx
+++ b/src/components/miniapp/PlanSection.tsx
@@ -355,13 +355,21 @@ export default function PlanSection() {
                             </motion.div>
                           )}
                         </div>
-                        <motion.p 
+                        <motion.p
                           className="text-body-sm text-muted-foreground font-sf-pro"
                           initial={{ opacity: 0 }}
                           animate={{ opacity: 1 }}
                           transition={{ delay: index * 0.1 + 0.3 }}
                         >
                           {plan.is_lifetime ? 'Lifetime access' : `${plan.duration_months} month${plan.duration_months > 1 ? 's' : ''}`}
+                        </motion.p>
+                        <motion.p
+                          className="text-body-xs text-muted-foreground mt-1"
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          transition={{ delay: index * 0.1 + 0.35 }}
+                        >
+                          Priority signals, VIP chat access & daily analysis
                         </motion.p>
                       </div>
                       <motion.div 

--- a/src/components/miniapp/QuickActions.tsx
+++ b/src/components/miniapp/QuickActions.tsx
@@ -91,7 +91,7 @@ export function QuickActions() {
       icon: <TrendingUp className="h-5 w-5" />,
       action: () => {
         const url = new URL(window.location.href);
-        url.searchParams.set('tab', 'status');
+        url.searchParams.set('tab', 'dashboard');
         window.history.pushState({}, '', url.toString());
         window.dispatchEvent(new PopStateEvent('popstate'));
         toast.success('Opening performance tracker...');

--- a/src/components/navigation/nav-items.ts
+++ b/src/components/navigation/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, TrendingUp, Settings, GraduationCap, MessageCircle } from "lucide-react";
+import { Home, TrendingUp, GraduationCap, MessageCircle, Shield } from "lucide-react";
 
 export interface NavItem {
   id: string;
@@ -45,9 +45,9 @@ export const NAV_ITEMS: NavItem[] = [
   {
     id: "dashboard",
     label: "Dashboard",
-    icon: Settings,
-    path: "/dashboard",
-    ariaLabel: "View member dashboard",
+    icon: Shield,
+    path: "/vip-dashboard",
+    ariaLabel: "View VIP dashboard",
     showOnMobile: true,
   },
 ];

--- a/src/pages/MiniApp.tsx
+++ b/src/pages/MiniApp.tsx
@@ -4,18 +4,16 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { 
-  Home, 
-  CreditCard, 
-  User, 
-  HelpCircle, 
-  MessageCircle, 
+import {
+  Home,
+  CreditCard,
+  HelpCircle,
+  MessageCircle,
+  LayoutDashboard,
   Zap,
   Menu,
   X,
-  ChevronDown,
-  Settings,
-  Shield
+  ChevronDown
 } from 'lucide-react';
 import { MobileSwipeContainer, MobilePullToRefresh, TouchFeedback, MobileScrollIndicator } from '@/components/ui/mobile-gestures';
 import { ThreeDEmoticon } from '@/components/ui/three-d-emoticons';
@@ -50,7 +48,14 @@ interface Plan {
 }
 
 export default function MiniApp() {
-  const [activeTab, setActiveTab] = useState('home');
+  const [activeTab, setActiveTab] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const param = new URLSearchParams(window.location.search).get('tab');
+      const valid = ['home', 'plan', 'dashboard', 'faq', 'ask'];
+      if (param && valid.includes(param)) return param;
+    }
+    return 'home';
+  });
   const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
   const [paymentStep, setPaymentStep] = useState<'plan' | 'payment' | 'confirmation'>('plan');
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -60,10 +65,22 @@ export default function MiniApp() {
   const tabs = [
     { id: 'home', label: 'Home', icon: Home },
     { id: 'plan', label: 'Plans', icon: CreditCard },
-    { id: 'status', label: 'Status', icon: User },
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'faq', label: 'FAQ', icon: HelpCircle },
     { id: 'ask', label: 'Support', icon: MessageCircle },
   ];
+
+  useEffect(() => {
+    const handler = () => {
+      const param = new URLSearchParams(window.location.search).get('tab');
+      const valid = ['home', 'plan', 'dashboard', 'faq', 'ask'];
+      if (param && valid.includes(param)) {
+        setActiveTab(param);
+      }
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -88,7 +105,7 @@ export default function MiniApp() {
         return (
           <PlanSection />
         );
-      case 'status':
+      case 'dashboard':
         return <StatusSection telegramData={null} />;
       case 'faq':
         return <FAQSection />;


### PR DESCRIPTION
## Summary
- surface VIP dashboard in main navigation
- support dashboard tab in mini app with URL-based tab selection
- enrich plan cards with concise benefit tagline

## Testing
- `npm run lint` *(fails: Unexpected any in supabase functions)*
- `npm test` *(fails: checkout-init rejects unauthenticated requests, start command omits Mini App button when env missing, miniapp edge host routes)*

------
https://chatgpt.com/codex/tasks/task_e_68be8fb37ec08322a0f27d94c82b8d8b