### PR TITLE
Improve tablist and layout semantics

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -111,7 +111,11 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
 
   if (compact) {
     return (
-      <footer className="bg-card/80 backdrop-blur-md border-t border-border/50 mt-4">
+      <footer
+        className="bg-card/80 backdrop-blur-md border-t border-border/50 mt-4"
+        role="contentinfo"
+        aria-label="Site footer"
+      >
         <div className="container mx-auto px-4 py-3">
           <div className="flex flex-col items-center gap-2">
             {/* Social Media Icons Row */}
@@ -148,7 +152,11 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
   }
 
   return (
-    <footer className="bg-card border-t border-border mt-auto">
+    <footer
+      className="bg-card border-t border-border mt-auto"
+      role="contentinfo"
+      aria-label="Site footer"
+    >
       <div className="container mx-auto px-4 py-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {/* Brand Section */}
@@ -167,9 +175,9 @@ const Footer: React.FC<FooterProps> = ({ compact = false }) => {
           {/* Quick Links */}
           <div className="space-y-4">
             <h4 className="text-md font-medium text-foreground">Quick Links</h4>
-            <nav className="flex flex-col space-y-2" aria-label="Footer navigation">
-              <Link 
-                to="/plans" 
+            <nav className="flex flex-col space-y-2" aria-label="Quick links">
+              <Link
+                to="/plans"
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 VIP Plans

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,17 +7,18 @@ import MobileMenu from "@/components/navigation/MobileMenu";
 
 const Header: React.FC = () => {
   return (
-    <header 
+    <header
       className={cn(
         "bg-gradient-navigation backdrop-blur-xl border-b border-border/50 sticky top-0 z-50",
         "shadow-lg shadow-primary/5 transition-all duration-300"
       )}
       role="banner"
+      aria-label="Site header"
     >
       <div className="container mx-auto px-4 sm:px-6 py-4">
         <div className="flex items-center justify-between">
-          <Link 
-            to="/" 
+          <Link
+            to="/"
             className={cn(
               "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-lg",
               "transition-all duration-300 hover:scale-105"

--- a/src/components/ui/responsive-header.tsx
+++ b/src/components/ui/responsive-header.tsx
@@ -100,15 +100,18 @@ interface ResponsiveTabsProps {
   activeTab: string;
   onTabChange: (tabId: string) => void;
   className?: string;
+  ariaLabel?: string;
 }
 
-export function ResponsiveTabs({ tabs, activeTab, onTabChange, className }: ResponsiveTabsProps) {
+export function ResponsiveTabs({ tabs, activeTab, onTabChange, className, ariaLabel = "Tabs" }: ResponsiveTabsProps) {
   return (
     <motion.nav
       className={cn(
         "sticky top-16 sm:top-20 lg:top-24 z-10 glass-card backdrop-blur-md border-b",
         className
       )}
+      role="tablist"
+      aria-label={ariaLabel}
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, delay: 0.1 }}
@@ -123,6 +126,10 @@ export function ResponsiveTabs({ tabs, activeTab, onTabChange, className }: Resp
           {tabs.map((tab, index) => (
             <motion.button
               key={tab.id}
+              role="tab"
+              id={`${tab.id}-tab`}
+              aria-selected={activeTab === tab.id}
+              aria-controls={`${tab.id}-panel`}
               onClick={() => onTabChange(tab.id)}
               className={cn(
                 "glass-tab flex flex-col items-center justify-center gap-0.5 sm:gap-1",

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
     orientation?: "horizontal" | "vertical";
     "aria-label"?: string;
   }
->(({ className, orientation = "horizontal", ...props }, ref) => (
+>(({ className, orientation = "horizontal", "aria-label": ariaLabel = "Tabs", ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
@@ -20,6 +20,7 @@ const TabsList = React.forwardRef<
     )}
     role="tablist"
     aria-orientation={orientation}
+    aria-label={ariaLabel}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary
- add default aria-label and orientation handling to tab lists
- enhance header and footer with contentinfo and banner labels
- upgrade responsive tab navigation with proper ARIA roles

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bea068d7108322bdc34c49ac9069d4