### PR TITLE
fix: improve VIP plan cards pricing

### DIFF
--- a/src/components/shared/LivePlansSection.tsx
+++ b/src/components/shared/LivePlansSection.tsx
@@ -12,6 +12,7 @@ import { HorizontalSnapScroll } from '@/components/ui/horizontal-snap-scroll';
 import { useToast } from '@/hooks/use-toast';
 import { callEdgeFunction, buildFunctionUrl } from '@/config/supabase';
 import PromoCodeInput from '@/components/billing/PromoCodeInput';
+import { formatPrice } from '@/lib/utils';
 
 interface Plan {
   id: string;
@@ -82,11 +83,9 @@ export const LivePlansSection = ({
     }
   };
 
-  const formatPrice = (plan: Plan) => {
-    if (plan.is_lifetime) {
-      return `$${plan.price}`;
-    }
-    return `$${plan.price}/mo`;
+  const formatPlanPrice = (plan: Plan) => {
+    const price = formatPrice(plan.price, plan.currency);
+    return plan.is_lifetime ? price : `${price}/mo`;
   };
 
   const isVipPlan = (name: string) => 
@@ -163,9 +162,9 @@ export const LivePlansSection = ({
                     </div>
                     <div className="text-right ui-stack-xs">
                       <div className="text-title font-bold text-primary">
-                        ${formatPrice(plan)}
+                        {formatPlanPrice(plan)}
                       </div>
-                      <div className="text-caption text-muted-foreground">USD</div>
+                      <div className="text-caption text-muted-foreground">{plan.currency}</div>
                     </div>
                   </div>
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatPrice(amount: number, currency: string = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -17,7 +17,7 @@ import {
   Sparkles
 } from "lucide-react";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
+import { cn, formatPrice } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { HorizontalSnapScroll } from "@/components/ui/horizontal-snap-scroll";
 import { callEdgeFunction } from "@/config/supabase";
@@ -127,9 +127,11 @@ const Plans: React.FC = () => {
             </div>
 
             <div className="space-y-2">
-              <div className="text-4xl font-bold text-primary">
-                ${plan.price}
-                {!isLifetime && <span className="text-lg text-muted-foreground">/mo</span>}
+              <div className="text-4xl font-bold text-primary flex items-baseline justify-center gap-1">
+                {formatPrice(plan.price, plan.currency)}
+                {!isLifetime && (
+                  <span className="text-lg text-muted-foreground">/mo</span>
+                )}
               </div>
               {isLifetime && (
                 <Badge variant="outline" className="text-yellow-600 border-yellow-600">


### PR DESCRIPTION
## Summary
- format subscription prices with a shared `formatPrice` util
- fix double dollar signs and show currency in VIP plan cards

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bea7f378808322b3e95614ab222697