### PR TITLE
Gracefully handle missing Supabase env vars

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
 import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
 import "./index.css";
 import { SUPABASE_ENV_ERROR } from "@/config/supabase";
 import EnvError from "@/components/EnvError";
 
-const root = document.getElementById("root")!;
-createRoot(root).render(
-  SUPABASE_ENV_ERROR ? <EnvError message={SUPABASE_ENV_ERROR} /> : <App />,
-);
+const rootEl = document.getElementById("root")!;
+const root = createRoot(rootEl);
+
+if (SUPABASE_ENV_ERROR) {
+  root.render(<EnvError message={SUPABASE_ENV_ERROR} />);
+} else {
+  import("./App.tsx")
+    .then(({ default: App }) => root.render(<App />))
+    .catch((err) => root.render(<EnvError message={String(err)} />));
+}


### PR DESCRIPTION
## Summary
- Avoid crashing when Supabase credentials are missing by lazily creating the client
- Defer loading `App` until environment variables are validated to show a friendly error screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bebc8b4e188322ad68a81a485b6290