### PR TITLE
fix: mark WebCheckout as client component

### DIFF
--- a/src/components/checkout/WebCheckout.tsx
+++ b/src/components/checkout/WebCheckout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";


### PR DESCRIPTION
## Summary
- declare WebCheckout as a client component so Next.js can use React hooks

## Testing
- `npm test` *(fails: deno not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bfc31afec0832294ff0c37753f09f8