### PR TITLE
feat: add helper functions and enforce profile role enum

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1040,7 +1040,7 @@ export type Database = {
           is_active: boolean | null
           last_name: string | null
           phone: string | null
-          role: string | null
+          role: Database["public"]["Enums"]["user_role_enum"]
           telegram_id: string | null
           updated_at: string | null
           username: string | null
@@ -1055,7 +1055,7 @@ export type Database = {
           is_active?: boolean | null
           last_name?: string | null
           phone?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["user_role_enum"]
           telegram_id?: string | null
           updated_at?: string | null
           username?: string | null
@@ -1070,7 +1070,7 @@ export type Database = {
           is_active?: boolean | null
           last_name?: string | null
           phone?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["user_role_enum"]
           telegram_id?: string | null
           updated_at?: string | null
           username?: string | null
@@ -1696,7 +1696,7 @@ export type Database = {
       }
       get_user_role: {
         Args: { user_telegram_id: string }
-        Returns: string
+        Returns: Database["public"]["Enums"]["user_role_enum"]
       }
       get_user_subscription_status: {
         Args: { telegram_user_id: string }
@@ -1765,7 +1765,7 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      user_role_enum: "admin" | "user"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20250912000100_enforce_profile_role_enum.sql
+++ b/supabase/migrations/20250912000100_enforce_profile_role_enum.sql
@@ -1,0 +1,13 @@
+-- Enforce valid roles via enum
+CREATE TYPE public.user_role_enum AS ENUM ('user', 'admin');
+
+-- Backfill existing roles
+UPDATE public.profiles
+SET role = 'user'
+WHERE role IS NULL OR role NOT IN ('user', 'admin');
+
+-- Alter column to use enum and enforce constraint
+ALTER TABLE public.profiles
+  ALTER COLUMN role TYPE public.user_role_enum USING role::public.user_role_enum,
+  ALTER COLUMN role SET DEFAULT 'user',
+  ALTER COLUMN role SET NOT NULL;

--- a/supabase/migrations/20250912000200_add_user_role_helpers.sql
+++ b/supabase/migrations/20250912000200_add_user_role_helpers.sql
@@ -1,0 +1,22 @@
+-- Helper functions for profile roles
+CREATE OR REPLACE FUNCTION public.get_user_role(user_telegram_id text)
+RETURNS public.user_role_enum
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+  SELECT role
+  FROM public.profiles
+  WHERE telegram_id = user_telegram_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_user_admin(user_telegram_id text)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+STABLE
+AS $$
+  SELECT public.get_user_role(user_telegram_id) = 'admin';
+$$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1040,7 +1040,7 @@ export type Database = {
           is_active: boolean | null
           last_name: string | null
           phone: string | null
-          role: string | null
+          role: Database["public"]["Enums"]["user_role_enum"]
           telegram_id: string | null
           updated_at: string | null
           username: string | null
@@ -1055,7 +1055,7 @@ export type Database = {
           is_active?: boolean | null
           last_name?: string | null
           phone?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["user_role_enum"]
           telegram_id?: string | null
           updated_at?: string | null
           username?: string | null
@@ -1070,7 +1070,7 @@ export type Database = {
           is_active?: boolean | null
           last_name?: string | null
           phone?: string | null
-          role?: string | null
+          role?: Database["public"]["Enums"]["user_role_enum"]
           telegram_id?: string | null
           updated_at?: string | null
           username?: string | null
@@ -1696,7 +1696,7 @@ export type Database = {
       }
       get_user_role: {
         Args: { user_telegram_id: string }
-        Returns: string
+        Returns: Database["public"]["Enums"]["user_role_enum"]
       }
       get_user_subscription_status: {
         Args: { telegram_user_id: string }
@@ -1765,7 +1765,7 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      user_role_enum: "admin" | "user"
     }
     CompositeTypes: {
       [_ in never]: never


### PR DESCRIPTION
## Summary
- add `user_role_enum` and migrate `profiles.role` to use it
- create `get_user_role` and `is_user_admin` helpers
- sync generated Supabase types with new enum and functions

## Testing
- `npm test` *(fails: deno: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd69efeac8322bddde1102c2bc1d3