### PR TITLE
chore: clean supabase urls

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,6 +1,6 @@
-NEXT_PUBLIC_SUPABASE_URL= https://qeejuomcapbdlhnjqjcc.supabase.co/
+NEXT_PUBLIC_SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # Server-side Supabase credentials
-SUPABASE_URL= https://qeejuomcapbdlhnjqjcc.supabase.co/
+SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 SUPABASE_ANON_KEY=


### PR DESCRIPTION
## Summary
- remove extra whitespace in Supabase URLs
- drop trailing slash from Supabase URLs

## Testing
- `deno test --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org -A --no-check`

------
https://chatgpt.com/codex/tasks/task_e_68bff4e540508322bb502da0e5a4b157