### PR TITLE
fix: resolve ts compilation issues

### DIFF
--- a/src/components/navigation/MobileMenu.tsx
+++ b/src/components/navigation/MobileMenu.tsx
@@ -3,21 +3,22 @@ import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { 
+import {
   Menu,
-  Home, 
-  CreditCard, 
-  Settings, 
+  Home,
+  CreditCard,
+  Settings,
   GraduationCap,
   User,
   LogIn,
-  X
+  X,
+  type LucideIcon,
 } from "lucide-react";
 
 interface NavItem {
   id: string;
   label: string;
-  icon: React.ElementType;
+  icon: LucideIcon;
   path: string;
   ariaLabel: string;
 }

--- a/src/components/navigation/nav-items.ts
+++ b/src/components/navigation/nav-items.ts
@@ -1,9 +1,16 @@
-import { Home, TrendingUp, GraduationCap, MessageCircle, Shield } from "lucide-react";
+import {
+  Home,
+  TrendingUp,
+  GraduationCap,
+  MessageCircle,
+  Shield,
+  type LucideIcon,
+} from "lucide-react";
 
 export interface NavItem {
   id: string;
   label: string;
-  icon: React.ElementType;
+  icon: LucideIcon;
   path: string;
   ariaLabel: string;
   showOnMobile?: boolean;

--- a/src/components/shared/ServiceStack.tsx
+++ b/src/components/shared/ServiceStack.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
   MessageSquare,
   Award,
+  type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -18,7 +19,7 @@ interface ServiceStackProps {
 }
 
 interface ServiceItem {
-  icon: React.ElementType;
+  icon: LucideIcon;
   title: string;
   description: string;
   color: string;

--- a/src/components/shared/ServiceStackCarousel.tsx
+++ b/src/components/shared/ServiceStackCarousel.tsx
@@ -1,7 +1,18 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight, TrendingUp, Star, Shield, Users, Sparkles, MessageSquare, Award } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  TrendingUp,
+  Star,
+  Shield,
+  Users,
+  Sparkles,
+  MessageSquare,
+  Award,
+  type LucideIcon,
+} from "lucide-react";
 import { FadeInOnView } from "@/components/ui/fade-in-on-view";
 import useEmblaCarousel from 'embla-carousel-react';
 import { cn } from "@/lib/utils";
@@ -14,7 +25,7 @@ interface ServiceStackCarouselProps {
 }
 
 interface ServiceItem {
-  icon: React.ElementType;
+  icon: LucideIcon;
   title: string;
   description: string;
   color: string;

--- a/src/hooks/useAnalytics.tsx
+++ b/src/hooks/useAnalytics.tsx
@@ -17,7 +17,7 @@ interface AnalyticsEvent {
 }
 
 export const useAnalytics = () => {
-  const sessionId = useRef<string>();
+  const sessionId = useRef<string | null>(null);
 
   useEffect(() => {
     // Generate session ID

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 
 export default {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- type icons with `LucideIcon` across navigation and service components to allow className props
- initialize analytics session ID with nullable ref
- update module resolution and Tailwind config for TypeScript compatibility

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff510b78c8322a1cb91981f15e140