### PR TITLE
chore: add env sync utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ npm run build:all
 
 ### Local Development
 ```bash
+# Ensure .env.local has all variables
+npm run sync-env
+
 # Start local stack
 supabase start
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "edge:smoke": "node scripts/smoke.js",
     "serve:functions": "supabase functions serve --no-verify-jwt",
     "drizzle:generate": "drizzle-kit generate",
-    "drizzle:migrate": "drizzle-kit migrate"
+    "drizzle:migrate": "drizzle-kit migrate",
+    "sync-env": "deno run -A scripts/sync-env.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -1,0 +1,46 @@
+// scripts/sync-env.ts
+// Sync missing variables from .env.example into .env.local, preserving existing values.
+
+const examplePath = ".env.example";
+const localPath = ".env.local";
+
+try {
+  await Deno.stat(localPath);
+} catch {
+  await Deno.writeTextFile(localPath, "");
+}
+
+const exampleContent = await Deno.readTextFile(examplePath);
+const localContent = await Deno.readTextFile(localPath);
+
+const localKeys = new Set<string>();
+for (const line of localContent.split(/\r?\n/)) {
+  const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+  if (m) localKeys.add(m[1]);
+}
+
+const additions: string[] = [];
+let buffer: string[] = [];
+for (const line of exampleContent.split(/\r?\n/)) {
+  if (/^\s*(#.*)?$/.test(line)) {
+    buffer.push(line);
+    continue;
+  }
+  const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+  if (m) {
+    const key = m[1];
+    if (!localKeys.has(key)) {
+      additions.push(...buffer, line);
+    }
+  }
+  buffer = [];
+}
+
+if (additions.length > 0) {
+  const prefix = localContent.endsWith("\n") || localContent.length === 0 ? "" : "\n";
+  const newContent = localContent + prefix + additions.join("\n") + "\n";
+  await Deno.writeTextFile(localPath, newContent);
+  console.log("Appended", additions.filter((l) => !l.startsWith("#") && l).length, "variables to .env.local");
+} else {
+  console.log(".env.local is up to date");
+}


### PR DESCRIPTION
## Summary
- add `sync-env` script to append missing env vars from `.env.example` to `.env.local`
- expose script via `npm run sync-env`
- document env sync step in local development docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bffd2b521c8322b32d9248ba1e52ff