### PR TITLE
Handle form submission crashes in auth and chat widgets

### DIFF
--- a/src/components/shared/ChatAssistantWidget.tsx
+++ b/src/components/shared/ChatAssistantWidget.tsx
@@ -29,7 +29,18 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
   const [messages, setMessages] = useState<{ role: "user" | "assistant"; content: string }[]>(() => {
     if (typeof window !== "undefined") {
       const stored = localStorage.getItem("chat-assistant-history");
-      return stored ? (JSON.parse(stored) as { role: "user" | "assistant"; content: string }[]).slice(-MAX_HISTORY) : [];
+      if (stored) {
+        try {
+          return (
+            JSON.parse(stored) as {
+              role: "user" | "assistant";
+              content: string;
+            }[]
+          ).slice(-MAX_HISTORY);
+        } catch {
+          localStorage.removeItem("chat-assistant-history");
+        }
+      }
     }
     return [];
   });


### PR DESCRIPTION
## Summary
- replace browser `alert` in auth sign-up with toast feedback
- wrap auth form handlers with try/catch/finally for reliable error reporting
- guard chat assistant history parsing against malformed localStorage data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0019462448322a68138d24139cde7