### PR TITLE
chore: validate environment before Lovable builds

### DIFF
--- a/build-dev.js
+++ b/build-dev.js
@@ -11,6 +11,14 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Verify required environment variables before building
+try {
+  execSync('npx tsx scripts/check-env.ts', { stdio: 'inherit' });
+} catch (error) {
+  console.error('❌ Environment check failed:', error.message);
+  process.exit(1);
+}
+
 // Read the current package.json
 const packageJsonPath = path.join(__dirname, 'package.json');
 let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));

--- a/lovable-build.js
+++ b/lovable-build.js
@@ -4,6 +4,14 @@ import { execSync } from 'node:child_process';
 
 console.log('🔧 Running Lovable build tasks...');
 
+// Ensure required environment variables are present
+try {
+  execSync('npx tsx scripts/check-env.ts', { stdio: 'inherit' });
+} catch (error) {
+  console.error('❌ Environment check failed:', error.message);
+  process.exit(1);
+}
+
 const tasks = [
   { cmd: 'npm run build', label: 'Next.js build' },
   { cmd: 'npm run build:miniapp', label: 'Miniapp build' }

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,0 +1,11 @@
+import { requireEnvVar } from "../src/utils/env.ts";
+
+try {
+  requireEnvVar("SUPABASE_URL");
+  requireEnvVar("SUPABASE_ANON_KEY");
+  console.log("✅ Required env vars present");
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `scripts/check-env.ts` to ensure SUPABASE env vars exist
- run env check from `build-dev.js` and `lovable-build.js` before building

## Testing
- `node -p "process.env.SUPABASE_URL"`
- `npx tsx scripts/check-env.ts` *(fails: Missing required env: SUPABASE_ANON_KEY)*
- `SUPABASE_ANON_KEY=dummy SUPABASE_URL=https://example.com npx tsx scripts/check-env.ts`
- `SUPABASE_URL=https://example.com SUPABASE_ANON_KEY=dummy node build-dev.js`
- `node lovable-build.js` *(fails: process aborted while running Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b0b0ae0832298c679dc2e89c47e