### PR TITLE
chore: add deno for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "autoprefixer": "^10.4.21",
+        "deno": "^2.4.4",
         "drizzle-kit": "^0.31.4",
         "eslint": "^9.35.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
@@ -124,6 +125,90 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@deno/darwin-arm64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/darwin-arm64/-/darwin-arm64-2.4.4.tgz",
+      "integrity": "sha512-mFxNliHJs3zHT515AoTICEYSv/zJTjXAU+QIZNXK3Yt1PaEHqbWYhxsMOp39Apb8ACgaAcGcJxPzsc6qecQVSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@deno/darwin-x64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/darwin-x64/-/darwin-x64-2.4.4.tgz",
+      "integrity": "sha512-3/15MyCithm77VFI9yesyLp+TLH5h3GQ0A2EEQISsWbJDWIOTMIAaL4suJHY0GMUKQZKOngoeyXyTqmGA/y0JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@deno/linux-arm64-glibc": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/linux-arm64-glibc/-/linux-arm64-glibc-2.4.4.tgz",
+      "integrity": "sha512-M0TnQI8j0JxI2A8nFkFMV4bGSzqFU25PX9ZR50OI58Eurp5WY+tmisAusWReVVPtgL7jaVpkS0sEIJyufVIxmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@deno/linux-x64-glibc": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/linux-x64-glibc/-/linux-x64-glibc-2.4.4.tgz",
+      "integrity": "sha512-KsNEe5nWgz54XdTkI06jgUXgXQzQ//mI2u24qPclSm/GNkAwAZMnzcBPnRSZ0gCbLJpy8nDc7fc+j2ITlLifVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@deno/win32-arm64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/win32-arm64/-/win32-arm64-2.4.4.tgz",
+      "integrity": "sha512-MPkhuVJVNF9PYiwrpRS0WfCwWxYmbB0CUgBE2+PC5FDbfmodfv+lv74w5HTPz2xITMdO4QqrOSSLz+JVCwjgSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@deno/win32-x64": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@deno/win32-x64/-/win32-x64-2.4.4.tgz",
+      "integrity": "sha512-3tZcX6Jx1T7OSyeSXmQpK7zjZwvcc4kTK7PXtkpLuDwFXmObOmsNdbMQXuOIXvcmLlnUnVYJEfEo63zBZWR11g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
@@ -5512,6 +5597,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/deno": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/deno/-/deno-2.4.4.tgz",
+      "integrity": "sha512-uD357dB8icmaCuRy1xRbltEzA8/bbfMYtCV9W6cv8HDLw9mmfi57SwY4bpEw+wWGjk/2vbg3cIEEAE+2O8DnTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "deno": "bin.cjs"
+      },
+      "optionalDependencies": {
+        "@deno/darwin-arm64": "2.4.4",
+        "@deno/darwin-x64": "2.4.4",
+        "@deno/linux-arm64-glibc": "2.4.4",
+        "@deno/linux-x64-glibc": "2.4.4",
+        "@deno/win32-arm64": "2.4.4",
+        "@deno/win32-x64": "2.4.4"
       }
     },
     "node_modules/detect-gpu": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "autoprefixer": "^10.4.21",
+    "deno": "^2.4.4",
     "drizzle-kit": "^0.31.4",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",


### PR DESCRIPTION
## Summary
- install deno as a dev dependency so test script can run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c064fca90883229d44740874c45a85